### PR TITLE
add preventScroll option

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -31,6 +31,7 @@ export type RouterProps = {
   data?: RouteDataFunc;
   children: JSX.Element;
   out?: object;
+  preventScroll?: boolean;
 } & (
   | {
       url?: never;
@@ -43,9 +44,10 @@ export type RouterProps = {
 );
 
 export const Router = (props: RouterProps) => {
-  const { source, url, base, data, out } = props;
+  const { source, url, base, data, out, preventScroll } = props;
   const integration =
-    source || (isServer ? staticIntegration({ value: url || "" }) : pathIntegration());
+    source ||
+    (isServer ? staticIntegration({ value: url || "" }) : pathIntegration({ preventScroll }));
   const routerState = createRouterContext(integration, base, data, out);
 
   return (

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -1,5 +1,11 @@
 import { createSignal, onCleanup } from "solid-js";
-import type { LocationChange, LocationChangeSignal, RouterIntegration, RouterUtils } from "./types";
+import type {
+  LocationChange,
+  LocationChangeSignal,
+  PathIntegration,
+  RouterIntegration,
+  RouterUtils
+} from "./types";
 
 function bindEvent(target: EventTarget, type: string, handler: EventListener) {
   target.addEventListener(type, handler);
@@ -66,7 +72,7 @@ export function staticIntegration(obj: LocationChange): RouterIntegration {
   };
 }
 
-export function pathIntegration() {
+export function pathIntegration({ preventScroll }: PathIntegration = {}) {
   return createIntegration(
     () => window.location.pathname + window.location.search + window.location.hash,
     ({ value, replace }) => {
@@ -75,7 +81,9 @@ export function pathIntegration() {
       } else {
         window.history.pushState(null, "", value);
       }
-      window.scrollTo(0, 0);
+      if (!preventScroll) {
+        window.scrollTo(0, 0);
+      }
     },
     notify => bindEvent(window, "popstate", () => notify())
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,10 @@ export interface LocationChange {
   replace?: boolean;
 }
 
+export interface PathIntegration {
+  preventScroll?: boolean;
+}
+
 export type LocationChangeSignal = [() => LocationChange, (next: LocationChange) => void];
 
 export interface RouterIntegration {


### PR DESCRIPTION
It would be nice to have an option for the router to not scroll upon path change, because I'm in a situation where I need complete control over scrolling during page transitions, which is why added preventScroll option to Router.

```ts
export const App = () => {
  const Routes = useRoutes(routes);
  
  return (
    <Router data={AppData} preventScroll={true}>
      <Routes />
    </Router>
  );
};
```