### PR TITLE
Add scroll option to navigation

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -165,6 +165,7 @@ export const Outlet = () => {
 interface LinkBaseProps extends JSX.AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string | undefined;
   replace?: boolean;
+  noScroll?: boolean;
 }
 
 function LinkBase(props: LinkBaseProps) {
@@ -187,7 +188,7 @@ function LinkBase(props: LinkBaseProps) {
       !(evt.metaKey || evt.altKey || evt.ctrlKey || evt.shiftKey)
     ) {
       evt.preventDefault();
-      navigate(to, { resolve: false, replace: props.replace || false });
+      navigate(to, { resolve: false, replace: props.replace || false, scroll: !props.noScroll });
     }
   };
 

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -69,13 +69,15 @@ export function staticIntegration(obj: LocationChange): RouterIntegration {
 export function pathIntegration() {
   return createIntegration(
     () => window.location.pathname + window.location.search + window.location.hash,
-    ({ value, replace }) => {
+    ({ value, replace, scroll }) => {
       if (replace) {
         window.history.replaceState(null, "", value);
       } else {
         window.history.pushState(null, "", value);
       }
-      window.scrollTo(0, 0);
+      if (scroll) {
+        window.scrollTo(0, 0);
+      }
     },
     notify => bindEvent(window, "popstate", () => notify())
   );
@@ -84,9 +86,11 @@ export function pathIntegration() {
 export function hashIntegration() {
   return createIntegration(
     () => window.location.hash.slice(1),
-    ({ value }) => {
+    ({ value, scroll}) => {
       window.location.hash = value;
-      window.scrollTo(0, 0);
+      if (scroll) {
+        window.scrollTo(0, 0);
+      }
     },
     notify => bindEvent(window, "hashchange", () => notify()),
     {

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -247,7 +247,7 @@ export function createRouterContext(
   if (basePath === undefined) {
     throw new Error(`${basePath} is not a valid base path`);
   } else if (basePath && !source().value) {
-    setSource({ value: basePath, replace: true });
+    setSource({ value: basePath, replace: true, scroll: false });
   }
 
   const [isRouting, start] = useTransition();
@@ -281,9 +281,10 @@ export function createRouterContext(
         return;
       }
 
-      const { replace, resolve } = {
+      const { replace, resolve, scroll } = {
         replace: false,
         resolve: true,
+        scroll: true,
         ...options
       };
 
@@ -302,9 +303,9 @@ export function createRouterContext(
           if (output) {
             output.url = resolvedTo;
           }
-          setSource({ value: resolvedTo, replace });
+          setSource({ value: resolvedTo, replace, scroll });
         } else {
-          const len = referrers.push({ value: current, replace });
+          const len = referrers.push({ value: current, replace, scroll });
           start(() => setReference(resolvedTo), () => {
             if (referrers.length === len) {
               navigateEnd(resolvedTo);
@@ -328,7 +329,8 @@ export function createRouterContext(
       if (next !== first.value) {
         setSource({
           value: next,
-          replace: first.replace
+          replace: first.replace,
+          scroll: first.scroll
         });
       }
       referrers.length = 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface Location<S extends LocationState = LocationState> extends Path 
 export interface NavigateOptions {
   resolve: boolean;
   replace: boolean;
+  scroll: boolean;
   state: LocationState;
 }
 
@@ -32,6 +33,7 @@ export type NavigatorFactory = (route?: RouteContext) => Navigator;
 export interface LocationChange {
   value: string;
   replace?: boolean;
+  scroll?: boolean;
 }
 
 export type LocationChangeSignal = [() => LocationChange, (next: LocationChange) => void];


### PR DESCRIPTION
Allow users to prevent automatic scrolling to top on individual navigations through the imperative `useNavigate` API or Link and NavLink components. 
- Adds `scroll` to navigation options which is passed to the source integration. Defaults to true if not provided to maintain existing behavior.
- Adds optional boolean prop `noScroll` to Link/NavLink components which will set the new `scroll` option to false if present.
- Updates path and hash integrations to only scroll to top when new `scroll` option is truthy.