### PR TITLE
Allow typing the `data` property for `RouteDataFuncArgs`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -44,14 +44,14 @@ export interface RouterIntegration {
   utils?: Partial<RouterUtils>;
 }
 
-export interface RouteDataFuncArgs {
-  data: unknown;
+export interface RouteDataFuncArgs<T = unknown> {
+  data: T extends RouteDataFunc ? ReturnType<T> : T;
   params: Params;
   location: Location;
   navigate: Navigator;
 }
 
-export type RouteDataFunc<T = unknown> = (args: RouteDataFuncArgs) => T;
+export type RouteDataFunc<T = unknown, R = unknown> = (args: RouteDataFuncArgs<T>) => R;
 
 export type RouteDefinition = {
   path: string | string[];


### PR DESCRIPTION
This will allow to have full type checking for `routeData` functions using the data provided by another `routeData` function.

```typescript
import { routeData as parentRouteData } from "../__index"

export function routeData(args: RouteDataFuncArgs<typeof parentRouteData>) {
  return createResource(
    () => args.data.user[0](),
    (user) => {}
  )
}
```

In the example above `args.data` is now fully typed instead of being `unknown`

Small breaking change `RouteDataFunc` now has 2 generic parameters the first one being the one passed to `RouteDataFuncArgs` where as it was previously the return type, the return type is now the second argument.

Although I would generally recommend not using `RouteDataFunc` so you can have the return type inferred like in the example above, I still modified it for people that might want to use it.