### PR TITLE
Feature routing with transition duration

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -101,7 +101,8 @@ export const Routes = (props: RoutesProps) => {
     on(matches, (nextMatches, prevMatches, prev: RouteContext[] | undefined) =>  {
       let equal = prevMatches && nextMatches.length === prevMatches.length;
       
-      const next: RouteContext[] = [], routeTransitionDuration = 1000;
+      const next: RouteContext[] = [],  
+            routeTransitionDuration = 1000; // Temporary, should come from user
 
       for (let i = 0, len = nextMatches.length; i < len; i++) {
         const prevMatch = prevMatches && prevMatches[i];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,10 @@ export {
   useNavigate,
   useParams,
   useResolvedPath,
-  useSearchParams
+  useSearchParams,
+  useIsRouteIn,
+  useIsRouteOut,
+  useIsRoute
 } from "./routing";
 export { mergeSearchString as _mergeSearchString } from "./utils";
 export type {

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -289,7 +289,7 @@ export function createRouterContext(
     signal: [source, setSource],
     utils = {}
   } = normalizeIntegration(integration);
-console.log(integration);
+
   const parsePath = utils.parsePath || (p => p);
   const renderPath = utils.renderPath || (p => p);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Component, JSX } from "solid-js";
+import { Component, JSX, Accessor, Setter } from "solid-js";
 
 export type Params = Record<string, string>;
 
@@ -131,11 +131,18 @@ export interface RouterOutput {
 }
 
 export interface RouterContext {
-  base: RouteContext;
-  out?: RouterOutput;
-  location: Location;
-  navigatorFactory: NavigatorFactory;
-  isRouting: () => boolean;
-  renderPath(path: string): string;
-  parsePath(str: string): string;
+  base                     : RouteContext;
+  out?                     : RouterOutput;
+  location                 : Location;
+  routesOut                : Accessor<RouteContext[]>,
+  setRoutesOut             : Setter<RouteContext[]>,
+  routeIn                  : Accessor<RouteContext | null>,
+  setRouteIn               : Setter<RouteContext | null>,
+  route                    : Accessor<RouteContext | null>,
+  setRoute                 : Setter<RouteContext | null>,
+  routePath                : () => string;
+  navigatorFactory         : NavigatorFactory;
+  isRouting                : () => boolean;
+  renderPath(path: string) : string;
+  parsePath(str: string)   : string;
 }


### PR DESCRIPTION
We are migrating from AngularDart to SolidJS right now. 

When evaluating the existing router solution there is a key peace we found missing for our applications to behave the same way. In AngularDart, we had our own routing component, which more or less did the same as this one.

But the feature missing is the ability to make smooth route transitions.

These are enabled by giving the previous active and the now active routes a user given amount of time in a "route-in" and "route-out" state. The user can use the state to make CSS animations.

The changes should be non-breaking for existing applications, although I would like to rename "isRouting" to "isLoading", since it's the loading state, although while loading it's also routing, so this would also be non-breaking.

Todos:

- [x] Defer state "Show when={}" state by user given time
- [ ] Get the time from the user (should be a value or a function, in ms)
- [x] Let components get their routing state (isRouteOut, isRouteIn, isRoute)
- [ ] Detect if the routing is a "back" routing, so an animation could run backwards
- [ ] Correctly get loading state and inform the user about the routing states 
- [ ] Write tests
___________________
Behavior in the DOM:  
![ex2](https://user-images.githubusercontent.com/12692409/183451668-095327f4-4764-4c26-85ce-fdf96afed9d5.gif)

Behavior on the page (slide-in/out but no handling of back in the way that the old elements comes back instead of acting as a new one):
![ex](https://user-images.githubusercontent.com/12692409/183451681-4461838a-837f-4c61-9505-b931c484ceda.gif)

I might not have used solid correctly at every place, I would love some help after it's working to clean up some parts if necessary.
