### PR TITLE
docs: fix incorrect path

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ export default function App() {
 
 3. Lazy-load route components
 
-This way, the `Users` and `Home` components will only be loaded if you're navigating to `/users` or `/home`, respectively.
+This way, the `Users` and `Home` components will only be loaded if you're navigating to `/users` or `/`, respectively.
 
 ```jsx
 import { lazy } from "solid-js";


### PR DESCRIPTION
There's no `/home` path specified.