### PR TITLE
Setting search params does not change route

### DIFF
--- a/src/routing.ts
+++ b/src/routing.ts
@@ -96,7 +96,7 @@ export const useSearchParams = <T extends Params>(): [
   const navigate = useNavigate();
   const setSearchParams = (params: SetParams, options?: Partial<NavigateOptions>) => {
     const searchString = untrack(() => mergeSearchString(location.search, params));
-    navigate(searchString, { scroll: false, ...options, resolve: true });
+    navigate(location.pathname + searchString, { scroll: false, ...options, resolve: true });
   };
   return [location.query as T, setSearchParams];
 };


### PR DESCRIPTION
Use the current location as a base when calling `setSearchParams`.

This doesn't fix the `from` route param though, however it might be desirable to know where the change was triggered.

Fixes #157 