### PR TITLE
Fixed Typo in README Dynamic Routes Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ const Home = lazy(() => import("./pages/Home"));
 
 export default function App() {
   return <>
-    <h1>My Site with Lots of Pages<h1/>
+    <h1>My Site with Lots of Pages</h1>
     <Routes>
       <Route path="/users" component={Users} />
       <Route path="/users/:id" component={User} />


### PR DESCRIPTION
Just fixing a typo I encountered when copy-pasting the dynamic routes example code.
