### PR TITLE
Fixed Typo in README Data Functions Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ import { lazy } from "solid-js";
 import { Route } from "@solidjs/router";
 import { fetchUser } ... 
 
-const User = lazy(() => import("/pages/users/[id].js"));
+const User = lazy(() => import("./pages/users/[id].js"));
 
 //Data function
 function UserData({params, location, navigate, data}) {


### PR DESCRIPTION
Fixing a typo I encountered when copy-pasting the data functions example code from the README file.
