### PR TITLE
Streamline anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ export default function App() {
 
 ## Create Links to Your Routes
 
-Use the `Link` component to create an anchor tag that takes you to a route:
+Use the `A` component to create an anchor tag that takes you to a route:
 
 ```jsx
 import { lazy } from "solid-js";
-import { Routes, Route, Link } from "@solidjs/router"
+import { Routes, Route, A } from "@solidjs/router"
 const Users = lazy(() => import("./pages/Users"));
 const Home = lazy(() => import("./pages/Home"));
 
@@ -132,8 +132,8 @@ export default function App() {
   return <>
     <h1>My Site with Lots of Pages</h1>
     <nav>
-      <Link href="/about">About</Link>
-      <Link href="/">Home</Link>
+      <A href="/about">About</A>
+      <A href="/">Home</A>
     </nav>
     <Routes>
       <Route path="/users" component={Users} />
@@ -144,33 +144,21 @@ export default function App() {
 }
 ```
 
-If you use `NavLink` instead of `Link`, the anchor tag will have an `active` class if its href matches the current location, and `inactive` otherwise. **Note:** By default matching includes locations that are descendents (eg. href `/users` matches locations `/users` and `/users/123`), use the boolean `end` prop to prevent matching these. This is particularly useful for links to the root route `/` which would match everything.
+The `<A>` tag also has an `active` class if its href matches the current location, and `inactive` otherwise. **Note:** By default matching includes locations that are descendents (eg. href `/users` matches locations `/users` and `/users/123`), use the boolean `end` prop to prevent matching these. This is particularly useful for links to the root route `/` which would match everything.
 
-Both of these components have these props:
 
 | prop     | type    | description                                                                                                                                                                              |
 |----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | href     | string  | The path of the route to navigate to. This will be resolved relative to the route that the link is in, but you can preface it with `/` to refer back to the root.                                                                                                                                                    |
 | noScroll | boolean | If true, turn off the default behavior of scrolling to the top of the new page                                                                                                           |
 | replace  | boolean | If true, don't add a new entry to the browser history. (By default, the new page will be added to the browser history, so pressing the back button will take you to the previous route.) |
-| state    | unknown | [Push this value](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) to the history stack when navigating  |
-
-
-`NavLink` additionally has:
-
-| prop     | type    | description                                                                                                                                                                              |
-|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| state    | unknown | [Push this value](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) to the history stack when navigating  |                                      |
 | inactiveClass | string  | The class to show when the link is inactive (when the current location doesn't match the link) |
 | activeClass | string | The class to show when the link is active                                                                                                        |
 | end  | boolean | If `true`, only considers the link to be active when the curent location matches the `href` exactly; if `false`, check if the current location _starts with_ `href` |
 
-
-
-
-If you have a same-domain path that you want to link to _without_ going through the router, set `rel="external"` on the link component.
-
 ### The Navigate Component
-Solid Router provides a `Navigate` component that works similarly to `Link` and `NavLink`, but it will _immediately_ navigate to the provided path as soon as the component is rendered. It also uses the `href` prop, but you have the additional option of passing a function to `href` that returns a path to navigate to:
+Solid Router provides a `Navigate` component that works similarly to `A`, but it will _immediately_ navigate to the provided path as soon as the component is rendered. It also uses the `href` prop, but you have the additional option of passing a function to `href` that returns a path to navigate to:
 
 ```jsx
 function getPath ({navigate, location}) {
@@ -222,7 +210,7 @@ export default function User () {
 
   const [userData] = createResource(() => params.id, fetchUser);
 
-  return <a href={userData.twitter}>{userData.name}</a>
+  return <A href={userData.twitter}>{userData.name}</A>
 }
 ```
 
@@ -271,7 +259,7 @@ To do this, create a function that fetches and returns the data using `createRes
 ```js
 import { lazy } from "solid-js";
 import { Route } from "@solidjs/router";
-import { fetchUser } ... 
+import { fetchUser } ...
 
 const User = lazy(() => import("./pages/users/[id].js"));
 
@@ -359,7 +347,7 @@ function PageWrapper () {
   return <div>
     <h1> We love our users! </h1>
     <Outlet/>
-    <Link href="/">Back Home</Link>
+    <A href="/">Back Home</A>
   </div>
 }
 
@@ -399,7 +387,7 @@ You don't have to use JSX to set up your routes; you can pass an object directly
 ```jsx
 import { lazy } from "solid-js";
 import { render } from "solid-js/web";
-import { Router, useRoutes, Link } from "@solidjs/router";
+import { Router, useRoutes, A } from "@solidjs/router";
 
 const routes = [
   {
@@ -430,12 +418,12 @@ function App() {
   return (
     <>
       <h1>Awesome Site</h1>
-      <Link class="nav" href="/">
+      <A class="nav" href="/">
         Home
-      </Link>
-      <Link class="nav" href="/users">
+      </A>
+      <A class="nav" href="/users">
         Users
-      </Link>
+      </A>
       <Routes />
     </>
   );

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -96,7 +96,7 @@ export const useSearchParams = <T extends Params>(): [
   const navigate = useNavigate();
   const setSearchParams = (params: SetParams, options?: Partial<NavigateOptions>) => {
     const searchString = untrack(() => mergeSearchString(location.search, params));
-    navigate(location.pathname + searchString, { scroll: false, ...options, resolve: true });
+    navigate(location.pathname + searchString, { scroll: false, ...options });
   };
   return [location.query as T, setSearchParams];
 };
@@ -418,10 +418,6 @@ export function createRouterContext(
   });
 
   if (!isServer) {
-    function isSvg<T extends SVGElement>(el: T | HTMLElement): el is T {
-      return el.namespaceURI === "http://www.w3.org/2000/svg";
-    }
-
     function handleAnchorClick(evt: MouseEvent) {
       if (
         evt.defaultPrevented ||
@@ -437,20 +433,17 @@ export function createRouterContext(
         .composedPath()
         .find(el => el instanceof Node && el.nodeName.toUpperCase() === "A") as
         | HTMLAnchorElement
-        | SVGAElement
         | undefined;
 
-      if (!a) return;
+      if (!a || !a.hasAttribute("link")) return;
 
-      const svg = isSvg(a);
-      const href = svg ? a.href.baseVal : a.href;
-      const target = svg ? a.target.baseVal : a.target;
-      if (target || (!href && !a.hasAttribute("state"))) return;
+      const href = a.href;
+      if (a.target || (!href && !a.hasAttribute("state"))) return;
 
       const rel = (a.getAttribute("rel") || "").split(/\s+/);
       if (a.hasAttribute("download") || (rel && rel.includes("external"))) return;
 
-      const url = svg ? new URL(href, document.baseURI) : new URL(href);
+      const url = new URL(href);
       const pathname = urlDecode(url.pathname);
       if (
         url.origin !== window.location.origin ||


### PR DESCRIPTION
It's been bugging me ever since working on SolidStart where we have both `@solidjs/router` and `@solidjs/meta` that there is a conflict with them both having `<Link>` components. And the truth of the matter is Solid Meta sorta takes priority because it is a wrapper over the `<link>` element.

Solid Router already diverted from React Router by using the `href` JSX attribute and we recently did work to make our anchors work even when not hydrated. So instead of having `<Link>` and `<NavLink>` we just have `<A>` (For the next while we still export `<Link>`, `<NavLink>` for backwards compat). This follows the pattern we've been using for the others allow enhancement. Not wanting to wrestle with having two components all the functionality of `<NavLink>` is built into `<A>`. 

At the same time while we need to intercept all anchor clicks I realize that our automatic opt-in of `<a>` is awkward. So with the next version we will go back to `<a>` just being normal and if you want Solid's router to do its thing use `<A>`. It still works without hydration but we now can leave your normal anchors alone.  Technically this is being handled by an attribute ("link") that is being added to the underlying `<a>` so you can still generate this without the Component but this just aligns it.

All in all this is a departure but it feels more like Solid to go this way and the right balance of power while getting out of your way.