### PR TITLE
Support for blocking navigation (via integration)

### DIFF
--- a/src/routing.ts
+++ b/src/routing.ts
@@ -325,14 +325,12 @@ export function createRouterContext(
   ) {
     // Untrack in case someone navigates in an effect - don't want to track `reference` or route paths
     untrack(() => {
-      if (utils.block && utils.block(to, options)) {
-        return;
-      }
+      const canLeave = () => !utils.block || !utils.block(reference(), to, options);
       if (typeof to === "number") {
         if (!to) {
           // A delta of 0 means stay at the current location, so it is ignored
         } else if (utils.go) {
-          utils.go(to);
+          canLeave() && utils.go(to);
         } else {
           console.warn("Router integration does not support relative routing");
         }
@@ -367,7 +365,7 @@ export function createRouterContext(
             output.url = resolvedTo;
           }
           setSource({ value: resolvedTo, replace, scroll, state: nextState });
-        } else {
+        } else if (canLeave()) {
           const len = referrers.push({ value: current, replace, scroll, state: state() });
           start(() => {
             setReference(resolvedTo);

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -325,6 +325,9 @@ export function createRouterContext(
   ) {
     // Untrack in case someone navigates in an effect - don't want to track `reference` or route paths
     untrack(() => {
+      if (utils.block && utils.block(to, options)) {
+        return;
+      }
       if (typeof to === "number") {
         if (!to) {
           // A delta of 0 means stay at the current location, so it is ignored

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,7 @@ export interface OutputMatch {
 }
 
 export interface Route {
-  key: unknown,
+  key: unknown;
   originalPath: string;
   pattern: string;
   element: () => JSX.Element;
@@ -116,7 +116,7 @@ export interface RouterUtils {
   renderPath(path: string): string;
   parsePath(str: string): string;
   go(delta: number): void;
-  block(to: string | number, options?: Partial<NavigateOptions>): boolean;
+  block(from: string, to: string | number, options?: Partial<NavigateOptions>): boolean;
 }
 
 export interface OutputMatch {

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,6 +116,7 @@ export interface RouterUtils {
   renderPath(path: string): string;
   parsePath(str: string): string;
   go(delta: number): void;
+  block(to: string | number, options?: Partial<NavigateOptions>): boolean;
 }
 
 export interface OutputMatch {


### PR DESCRIPTION
Adds minimal core support for blocking navigation.  Use case is providing some control over navigating away from a route that has unsaved changes.

Leaving a route can occur in many ways - and blocking them all is challenging:
1. User clicks a normal anchor
2. User clicks a router `<A>` component
3. Code calls navigate
4. Code calls browser history APIs directly
5. User refreshes the page
6. User types in URL
7. more?...

Some of these can be handled somewhat in user land, eg by listening to `window.beforeunload` for (5 & 6), but others need some assistance from router.

In Solid's case, blocking seems relevant in two places:
a) The router internals (ie the `navigateFromRoute` function) handles 2 & 3
b) The router integration (ie suppress notifying the location has changed) handles 1.

This PR is specific to (a) and enables (b).  It enables the router integration to optionally provide a `block` function that will bail out of `navigateFromRoute`.  

It is expected that `block` function will originate from the app, probably as an option to the integration.  It is also likely the `block` function will itself be used to support some higher-level component such as a `useBlocker` hook - but these may be best experimented with in userland via custom integrations.  It is noteworthy the parameters to the `block` function are the same as those used when calling `navigate`.  This is intentional as the app may wish to save those parameters and block immediate navigation - and then kick navigation off again in the near future - for example if the user confirms they are okay to leave the page without saving.

> Note
> This PR does not update the built-in integrations to utilize the `block` function.  I have tested with a custom integration here that implements (b) - but I think that is a separate concern.


