### PR TITLE
Support for blocking navigation (useBeforeLeave)

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,9 @@ Used to define routes via a config object instead of JSX. See [Config Based Rout
 
 `useBeforeLeave` takes a function that will be called prior to leaving a route.  The function will be called with:
 
-- to (_path: string |number_, _options: NavigateOptions_}: same as passed to the `navigate` causing the route change.
+- from (_string_): path prior to `navigate`.
+- to (_string | number_}: path passed to `navigate`.
+- options (_NavigateOptions_}: options passed to `navigate`.
 - preventDefault (_void function_): call to block the route change.
 - defaultPrevented (_readonly boolean_): true if any previously called leave handlers called preventDefault().
 - retry (_void function_, _force?: boolean_ ): call to retry the same navigation, perhaps after confirming with the user. Pass `true` to skip running the leave handlers again (ie force navigate without confirming).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It supports all of Solid's SSR methods and has Solid's transitions baked in, so 
   - [useRouteData](#useroutedata)
   - [useMatch](#usematch)
   - [useRoutes](#useroutes)
+  - [useBeforeLeave](#usebeforeleave)
 
 ## Getting Started
 
@@ -538,3 +539,30 @@ return <div classList={{ active: Boolean(match()) }} />;
 ### useRoutes
 
 Used to define routes via a config object instead of JSX. See [Config Based Routing](#config-based-routing).
+
+### useBeforeLeave
+
+`useBeforeLeave` takes a function that will be called prior to leaving a route.  The function will be called with:
+
+- to (_path: string |number_, _options: NavigateOptions_}: same as passed to the `navigate` causing the route change.
+- preventDefault (_void function_): call this to block the route change.
+- defaultPrevented (_readonly boolean_): true if any previously called leave handlers called preventDefault().
+- forceRetry (_void function_): call this to force the same navigation, perhaps after confirming with the user.
+
+Example usage:
+```js
+useBeforeLeave((e: BeforeLeaveEventArgs) => {
+  if (form.isDirty && !e.defaultPrevented) {
+    e.preventDefault();
+    // prompt user async and preventDefault to block immediately
+    setTimeout(() => {
+      if (window.confirm("Discard unsaved changes - are you sure?")) {
+        // user wants to proceed anyway
+        e.forceRetry(); 
+      }
+    }, 100);
+  }
+});
+```
+
+

--- a/README.md
+++ b/README.md
@@ -545,20 +545,20 @@ Used to define routes via a config object instead of JSX. See [Config Based Rout
 `useBeforeLeave` takes a function that will be called prior to leaving a route.  The function will be called with:
 
 - to (_path: string |number_, _options: NavigateOptions_}: same as passed to the `navigate` causing the route change.
-- preventDefault (_void function_): call this to block the route change.
+- preventDefault (_void function_): call to block the route change.
 - defaultPrevented (_readonly boolean_): true if any previously called leave handlers called preventDefault().
-- forceRetry (_void function_): call this to force the same navigation, perhaps after confirming with the user.
+- retry (_void function_, _force?: boolean_ ): call to retry the same navigation, perhaps after confirming with the user. Pass `true` to skip running the leave handlers again (ie force navigate without confirming).
 
 Example usage:
 ```js
 useBeforeLeave((e: BeforeLeaveEventArgs) => {
   if (form.isDirty && !e.defaultPrevented) {
+    // preventDefault to block immediately and prompt user async
     e.preventDefault();
-    // prompt user async and preventDefault to block immediately
     setTimeout(() => {
       if (window.confirm("Discard unsaved changes - are you sure?")) {
-        // user wants to proceed anyway
-        e.forceRetry(); 
+        // user wants to proceed anyway so retry with force=true
+        e.retry(true); 
       }
     }, 100);
   }

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ Used to define routes via a config object instead of JSX. See [Config Based Rout
 
 `useBeforeLeave` takes a function that will be called prior to leaving a route.  The function will be called with:
 
-- from (_string_): path prior to `navigate`.
+- from (_Location_): current location (before change).
 - to (_string | number_}: path passed to `navigate`.
 - options (_NavigateOptions_}: options passed to `navigate`.
 - preventDefault (_void function_): call to block the route change.

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -200,7 +200,7 @@ export interface AnchorProps extends Omit<JSX.AnchorHTMLAttributes<HTMLAnchorEle
 }
 export function A(props: AnchorProps) {
   props = mergeProps({ inactiveClass: "inactive", activeClass: "active" }, props);
-  const [, rest] = splitProps(props, ["href", "state", "activeClass", "inactiveClass", "end"]);
+  const [, rest] = splitProps(props, ["href", "state", "class", "activeClass", "inactiveClass", "end"]);
   const to = useResolvedPath(() => props.href);
   const href = useHref(to);
   const location = useLocation();
@@ -219,6 +219,7 @@ export function A(props: AnchorProps) {
       href={href() || props.href}
       state={JSON.stringify(props.state)}
       classList={{
+        ...(props.class && { [props.class]: true }),
         [props.inactiveClass!]: !isActive(),
         [props.activeClass!]: isActive(),
         ...rest.classList

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 export * from "./components";
 export * from "./integration";
+export * from "./lifecycle";
 export {
   useRouteData,
   useHref,
@@ -11,7 +12,6 @@ export {
   useResolvedPath,
   useSearchParams,
   useBeforeLeave,
-  confirmLeave
 } from "./routing";
 export { mergeSearchString as _mergeSearchString } from "./utils";
 export type {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,9 @@ export {
   useNavigate,
   useParams,
   useResolvedPath,
-  useSearchParams
+  useSearchParams,
+  useBeforeLeave,
+  confirmLeave
 } from "./routing";
 export { mergeSearchString as _mergeSearchString } from "./utils";
 export type {
@@ -26,5 +28,6 @@ export type {
   RouterIntegration,
   RouterOutput,
   RouterUtils,
-  SetParams
+  SetParams,
+  BeforeLeaveEventArgs
 } from "./types";

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -9,10 +9,9 @@ export function createBeforeLeave(): BeforeLeaveLifecycle {
   }
 
   let ignore = false;
-  function confirm(from: string, to: string | number, options?: Partial<NavigateOptions>) {
+  function confirm(to: string | number, options?: Partial<NavigateOptions>) {
     if (ignore) return true;
     const e = {
-      from,
       to,
       options,
       defaultPrevented: false,
@@ -21,10 +20,11 @@ export function createBeforeLeave(): BeforeLeaveLifecycle {
     for (const l of listeners)
       l.listener({
         ...e,
+        from: l.router.location,
         retry: (force?: boolean) => {
           force && (ignore = true);
           try {
-            l.navigate(to as string, options);
+            l.router.navigatorFactory()(to as string, options);
           } finally {
             force && (ignore = false);
           }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -20,11 +20,11 @@ export function createBeforeLeave(): BeforeLeaveLifecycle {
     for (const l of listeners)
       l.listener({
         ...e,
-        from: l.router.location,
+        from: l.location,
         retry: (force?: boolean) => {
           force && (ignore = true);
           try {
-            l.router.navigatorFactory()(to as string, options);
+            l.navigate(to as string, options);
           } finally {
             force && (ignore = false);
           }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -10,7 +10,7 @@ export function createBeforeLeave(): BeforeLeaveLifecycle {
 
   let ignore = false;
   function confirm(to: string | number, options?: Partial<NavigateOptions>) {
-    if (ignore) return true;
+    if (ignore) return !(ignore = false);
     const e = {
       to,
       options,
@@ -23,11 +23,7 @@ export function createBeforeLeave(): BeforeLeaveLifecycle {
         from: l.location,
         retry: (force?: boolean) => {
           force && (ignore = true);
-          try {
-            l.navigate(to as string, options);
-          } finally {
-            force && (ignore = false);
-          }
+          l.navigate(to as string, options);
         }
       });
     return !e.defaultPrevented;

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -104,7 +104,7 @@ export const useSearchParams = <T extends Params>(): [
 };
 
 export const useBeforeLeave = (listener: (e: BeforeLeaveEventArgs) => void) => {
-  const s = useRouter().beforeLeave.subscribe({ listener, navigate: useNavigate() });
+  const s = useRouter().beforeLeave.subscribe({ listener, router: useRouter() });
   onCleanup(s);
 };
 
@@ -337,7 +337,7 @@ export function createRouterContext(
         if (!to) {
           // A delta of 0 means stay at the current location, so it is ignored
         } else if (utils.go) {
-          beforeLeave.confirm(reference(), to, options) && utils.go(to);
+          beforeLeave.confirm(to, options) && utils.go(to);
         } else {
           console.warn("Router integration does not support relative routing");
         }
@@ -372,7 +372,7 @@ export function createRouterContext(
             output.url = resolvedTo;
           }
           setSource({ value: resolvedTo, replace, scroll, state: nextState });
-        } else if (beforeLeave.confirm(reference(), to, options)) {
+        } else if (beforeLeave.confirm(resolvedTo, options)) {
           const len = referrers.push({ value: current, replace, scroll, state: state() });
           start(() => {
             setReference(resolvedTo);

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -102,23 +102,20 @@ export const useSearchParams = <T extends Params>(): [
   return [location.query as T, setSearchParams];
 };
 
-let leaveHandlers: {
+let leaveHandlers = new Set<{
   handler: BeforeLeaveHandler;
   navigate: Navigator;
-}[] = [];
+}>();
 export const useBeforeLeave = (handler: BeforeLeaveHandler) => {
   const h = { handler, navigate: useNavigate() };
-  leaveHandlers.push(h);
-  onCleanup(() => {
-    const idx = leaveHandlers.indexOf(h);
-    idx > -1 && leaveHandlers.splice(idx, 1);
-  });
+  leaveHandlers.add(h);
+  onCleanup(() => leaveHandlers.delete(h));
 };
 
 let skipConfirmLeave = false;
 export function confirmLeave(path: string | number, options?: Partial<NavigateOptions>) {
   if (skipConfirmLeave) return true;
-  let e = {
+  const e = {
     defaultPrevented: false,
     to: { path, options },
     preventDefault: () => ((e.defaultPrevented as boolean) = true)

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -126,12 +126,12 @@ export function confirmLeave(path: string | number, options?: Partial<NavigateOp
   for (const h of leaveHandlers)
     h.handler({
       ...e,
-      forceRetry: () => {
-        skipConfirmLeave = true;
+      retry: (force?: boolean) => {
+        force && (skipConfirmLeave = true);
         try {
           h.navigate(path as string, options);
         } finally {
-          skipConfirmLeave = false;
+          force && (skipConfirmLeave = false);
         }
       }
     });

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -104,7 +104,7 @@ export const useSearchParams = <T extends Params>(): [
 };
 
 export const useBeforeLeave = (listener: (e: BeforeLeaveEventArgs) => void) => {
-  const s = useRouter().beforeLeave.subscribe({ listener, router: useRouter() });
+  const s = useRouter().beforeLeave.subscribe({ listener, location: useLocation(), navigate: useNavigate()});
   onCleanup(s);
 };
 

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -369,9 +369,7 @@ export function createRouterContext(
         if (!to) {
           // A delta of 0 means stay at the current location, so it is ignored
         } else if (utils.go) {
-          if (confirmLeave(reference(), to, options)) {
-            utils.go(to);
-          }
+          confirmLeave(reference(), to, options) && utils.go(to);
         } else {
           console.warn("Router integration does not support relative routing");
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,7 +144,7 @@ export interface BeforeLeaveEventArgs {
   readonly defaultPrevented: boolean;
   to: { path: string | number; options?: Partial<NavigateOptions> };
   preventDefault(): void;
-  forceRetry(): void
+  retry(force?: boolean): void
 }
 
 export interface BeforeLeaveHandler {

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,7 +153,8 @@ export interface BeforeLeaveEventArgs {
 
 export interface BeforeLeaveListener {
   listener(e: BeforeLeaveEventArgs): void;
-  router: RouterContext;
+  location: Location
+  navigate: Navigator;
 }
 
 export interface BeforeLeaveLifecycle {

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,7 @@ export interface OutputMatch {
 }
 
 export interface Route {
-  key: unknown,
+  key: unknown;
   originalPath: string;
   pattern: string;
   element: () => JSX.Element;
@@ -138,4 +138,15 @@ export interface RouterContext {
   isRouting: () => boolean;
   renderPath(path: string): string;
   parsePath(str: string): string;
+}
+
+export interface BeforeLeaveEventArgs {
+  readonly defaultPrevented: boolean;
+  to: { path: string | number; options?: Partial<NavigateOptions> };
+  preventDefault(): void;
+  forceRetry(): void
+}
+
+export interface BeforeLeaveHandler {
+  (e: BeforeLeaveEventArgs): void;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,7 +143,7 @@ export interface RouterContext {
 }
 
 export interface BeforeLeaveEventArgs {
-  from: string;
+  from: Location;
   to: string | number;
   options?: Partial<NavigateOptions>;
   readonly defaultPrevented: boolean;
@@ -153,10 +153,10 @@ export interface BeforeLeaveEventArgs {
 
 export interface BeforeLeaveListener {
   listener(e: BeforeLeaveEventArgs): void;
-  navigate: Navigator;
+  router: RouterContext;
 }
 
 export interface BeforeLeaveLifecycle {
   subscribe(listener: BeforeLeaveListener): () => void;
-  confirm(from: string, to: string | number, options?: Partial<NavigateOptions>): boolean;
+  confirm(to: string | number, options?: Partial<NavigateOptions>): boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,6 +116,7 @@ export interface RouterUtils {
   renderPath(path: string): string;
   parsePath(str: string): string;
   go(delta: number): void;
+  beforeLeave: BeforeLeaveLifecycle;
 }
 
 export interface OutputMatch {
@@ -138,6 +139,7 @@ export interface RouterContext {
   isRouting: () => boolean;
   renderPath(path: string): string;
   parsePath(str: string): string;
+  beforeLeave: BeforeLeaveLifecycle;
 }
 
 export interface BeforeLeaveEventArgs {
@@ -149,6 +151,12 @@ export interface BeforeLeaveEventArgs {
   retry(force?: boolean): void;
 }
 
-export interface BeforeLeaveHandler {
-  (e: BeforeLeaveEventArgs): void;
+export interface BeforeLeaveListener {
+  listener(e: BeforeLeaveEventArgs): void;
+  navigate: Navigator;
+}
+
+export interface BeforeLeaveLifecycle {
+  subscribe(listener: BeforeLeaveListener): () => void;
+  confirm(from: string, to: string | number, options?: Partial<NavigateOptions>): boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,10 +141,12 @@ export interface RouterContext {
 }
 
 export interface BeforeLeaveEventArgs {
+  from: string;
+  to: string | number;
+  options?: Partial<NavigateOptions>;
   readonly defaultPrevented: boolean;
-  to: { path: string | number; options?: Partial<NavigateOptions> };
   preventDefault(): void;
-  retry(force?: boolean): void
+  retry(force?: boolean): void;
 }
 
 export interface BeforeLeaveHandler {


### PR DESCRIPTION
Adds this...

### useBeforeLeave

`useBeforeLeave` takes a function that will be called prior to leaving a route.  The function will be called with:

- from (_Location_): current location (before change).
- to (_string | number_}: path passed to `navigate`.
- options (_NavigateOptions_}: options passed to `navigate`.
- preventDefault (_void function_): call to block the route change.
- defaultPrevented (_readonly boolean_): true if any previously called leave handlers called preventDefault().
- retry (_void function_, _force?: boolean_ ): call to retry the same navigation, perhaps after confirming with the user. Pass `true` to skip running the leave handlers again (ie force navigate without confirming).

Example usage:
```js
useBeforeLeave((e: BeforeLeaveEventArgs) => {
  if (form.isDirty && !e.defaultPrevented) {
    // preventDefault to block immediately and prompt user async
    e.preventDefault();
    setTimeout(() => {
      if (window.confirm("Discard unsaved changes - are you sure?")) {
        // user wants to proceed anyway so retry with force=true
        e.retry(true); 
      }
    }, 100);
  }
});
```

## NOTE LIMITATIONS
This PR only adds support to block navigations originating from the router (eg `<Link>`, `useNavigate()`).

Blocking navigations originating in the browser (back/forward, plain anchors) can also be done and requires either a custom path/hash integration, or `solid-router` to extend its built-in integrations. [This branch](https://github.com/cselnz/solid-router/tree/publish) includes this addtional behavior.

Finally, users may wish to block full page document navigations (ie using window `beforeunload` event) but that should be handled in application code directly (outside the scope of the router).

