### PR TITLE
Fix #176 (2nd issue) - loosing trailing slash on query

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,9 @@ const hasSchemeRegex = /^(?:[a-z0-9]+:)?\/\//i;
 const trimPathRegex = /^\/+|\/+$/g;
 
 function normalize(path: string, omitSlash: boolean = false) {
-  const s = path.replace(trimPathRegex, "");
+  const p = path.split("?");
+  p[0] = p[0].replace(trimPathRegex, "");
+  const s = p.join("?");
   return s ? (omitSlash || /^[?#]/.test(s) ? s : "/" + s) : "";
 }
 


### PR DESCRIPTION
This `normalize` utility is passed paths that _can_ include a query string eg `/login?ReturnTo=/` and was stripping off the trailing slash.

It is probably still intended to strip trailing slashes from the "path" portion.  So this PR takes the approach of splitting on any "?", trimming the first item then joining the items again with "?".

Hopefully helpful but feel free to discard if not. :)
