### PR TITLE
Fix #176 - url was being decoded, trimmed, and written back unencoded

### DIFF
--- a/src/routing.ts
+++ b/src/routing.ts
@@ -451,7 +451,7 @@ export function createRouterContext(
       )
         return;
 
-      const to = parsePath(pathname + urlDecode(url.search, true) + urlDecode(url.hash));
+      const to = parsePath(url.pathname + url.search + url.hash);
       const state = a.getAttribute("state");
 
       evt.preventDefault();


### PR DESCRIPTION
Fixes #176.

It looks like this issue was introduced by [this commit](https://github.com/solidjs/solid-router/commit/13d33e7fb943b9d5255ebc96fbb3e58bc5da1b4a) back in May when fixing issue #112.

The problem was decoded (invalid) URLs were being written back into the browser address bar (potentially after having trailing characters removed from query string).

I've also tested the original issue #112 with this change in place and it still works correctly....
 `<Link href="/bla bla bla">Blah</Link>`...
...is correctly matched against route `{ path: '/bla bla bla', component: Blah }`...
... and shows `/bla%20bla%20bla` in the address bar.