### PR TITLE
Fix #184 - Link not matching trailing /

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -209,7 +209,7 @@ export function A(props: AnchorProps) {
     if (to_ === undefined) return false;
     const path = normalizePath(to_.split(/[?#]/, 1)[0]).toLowerCase();
     const loc = normalizePath(location.pathname).toLowerCase();
-return props.end ? path === loc : loc.startsWith(path);
+    return props.end ? path === loc : loc.startsWith(path);
   });
 
   return (

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -27,7 +27,7 @@ import type {
   RouteDefinition,
   RouterIntegration
 } from "./types";
-import { joinPaths } from "./utils";
+import { joinPaths, normalizePath } from "./utils";
 
 declare module "solid-js" {
   namespace JSX {
@@ -207,9 +207,9 @@ export function A(props: AnchorProps) {
   const isActive = createMemo(() => {
     const to_ = to();
     if (to_ === undefined) return false;
-    const path = to_.split(/[?#]/, 1)[0].toLowerCase();
-    const loc = location.pathname.toLowerCase();
-    return props.end ? path === loc : loc.startsWith(path);
+    const path = normalizePath(to_.split(/[?#]/, 1)[0]).toLowerCase();
+    const loc = normalizePath(location.pathname).toLowerCase();
+return props.end ? path === loc : loc.startsWith(path);
   });
 
   return (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import type { Params, PathMatch, Route, SetParams } from "./types";
 const hasSchemeRegex = /^(?:[a-z0-9]+:)?\/\//i;
 const trimPathRegex = /^\/+|\/+$/g;
 
-function normalize(path: string, omitSlash: boolean = false) {
+export function normalizePath(path: string, omitSlash: boolean = false) {
   const s = path.replace(trimPathRegex, "");
   return s ? (omitSlash || /^[?#]/.test(s) ? s : "/" + s) : "";
 }
@@ -13,8 +13,8 @@ export function resolvePath(base: string, path: string, from?: string): string |
   if (hasSchemeRegex.test(path)) {
     return undefined;
   }
-  const basePath = normalize(base);
-  const fromPath = from && normalize(from);
+  const basePath = normalizePath(base);
+  const fromPath = from && normalizePath(from);
   let result = "";
   if (!fromPath || path.startsWith("/")) {
     result = basePath;
@@ -23,7 +23,7 @@ export function resolvePath(base: string, path: string, from?: string): string |
   } else {
     result = fromPath;
   }
-  return (result || "/") + normalize(path, !result);
+  return (result || "/") + normalizePath(path, !result);
 }
 
 export function invariant<T>(value: T | null | undefined, message: string): T {
@@ -34,7 +34,7 @@ export function invariant<T>(value: T | null | undefined, message: string): T {
 }
 
 export function joinPaths(from: string, to: string): string {
-  return normalize(from).replace(/\/*(\*.*)?$/g, "") + normalize(to);
+  return normalizePath(from).replace(/\/*(\*.*)?$/g, "") + normalizePath(to);
 }
 
 export function extractSearchParams(url: URL): Params {


### PR DESCRIPTION
Fix #184 
Issue summary : `<A>` was not showing as active for `domain.com/solidjs/` due to trailing slash.

This PR exposes the `normalize()` utility function as `normalizePath()` so it can be used by the `<A>` component when comparing active paths.