### PR TITLE
Fix #183 - setSearchParams duplicates base path

### DIFF
--- a/src/routing.ts
+++ b/src/routing.ts
@@ -96,7 +96,7 @@ export const useSearchParams = <T extends Params>(): [
   const navigate = useNavigate();
   const setSearchParams = (params: SetParams, options?: Partial<NavigateOptions>) => {
     const searchString = untrack(() => mergeSearchString(location.search, params));
-    navigate(location.pathname + searchString, { scroll: false, resolve: false, ...options });
+    navigate(location.pathname + searchString + location.hash, { scroll: false, resolve: false, ...options });
   };
   return [location.query as T, setSearchParams];
 };

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -96,7 +96,7 @@ export const useSearchParams = <T extends Params>(): [
   const navigate = useNavigate();
   const setSearchParams = (params: SetParams, options?: Partial<NavigateOptions>) => {
     const searchString = untrack(() => mergeSearchString(location.search, params));
-    navigate(location.pathname + searchString, { scroll: false, ...options });
+    navigate(location.pathname + searchString, { scroll: false, resolve: false, ...options });
   };
   return [location.query as T, setSearchParams];
 };


### PR DESCRIPTION
Fixes #183.

The full `location.pathname` is being passed to `navigate` so it does not need to be resolved (which added the duplicate base prefix).