### PR TITLE
Fix issue: #197

### DIFF
--- a/src/routing.ts
+++ b/src/routing.ts
@@ -181,8 +181,8 @@ export function createBranches(
       const routes = createRoutes(def, base, fallback);
       for (const route of routes) {
         stack.push(route);
-
-        if (def.children) {
+        const isEmptyArray = Array.isArray(def.children) && def.children.length === 0
+        if (def.children && !isEmptyArray ) {
           createBranches(def.children, route.pattern, fallback, stack, branches);
         } else {
           const branch = createBranch([...stack], branches.length);


### PR DESCRIPTION
Fix issue [#197 ](https://github.com/solidjs/solid-router/issues/197).
Issue summary : Parent rout was not rendering without error or any information if children is empty.

This PR add condition for children routes.  If children are empty parent route will render anyway.