### PR TITLE
Gurad Added with redirect also active link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,33 @@ return (
     <button onClick={() => setSearchParams({ page: searchParams.page + 1 })}>Next Page</button>
   </div>
 );
+
+
+```
+### Guard
+
+When notLogin(in below) is true that mean it will not do anything but if it is string it will redirect to the string that we get in return.
+
+```js
+const notLogin: Accessor<string | true> = createMemo(() => {
+  if (JSON.parse(JSON.stringify(LoginService.get())).login != false) { return '/' }
+  return true;
+});
+const App: Component = () => {
+  return (
+    <>
+      <Router>
+        <Routes>
+          <Route path='/' component={Public_Layout}>
+            <Route path='' component={HomePage} />
+            <Route path='login/' guard={notLogin} component={Login_Page} />
+            <Route path='register/' guard={notLogin} component={RegisterPage} />
+          </Route>
+        </Routes>
+      </Router>
+    </>
+  );
+};
 ```
 
 ### useIsRouting

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1,6 +1,6 @@
 /*@refresh skip*/
 
-import type { Component, JSX } from "solid-js";
+import type { Accessor, Component, JSX } from "solid-js";
 import { children, createMemo, createRoot, mergeProps, on, Show, splitProps } from "solid-js";
 import { isServer } from "solid-js/web";
 import { pathIntegration, staticIntegration } from "./integration";
@@ -140,7 +140,7 @@ export const Routes = (props: RoutesProps) => {
     <Show when={routeStates() && root}>
       {
         ((route: any) => (
-          <RouteContextObj.Provider value={route}>{route.outlet()}</RouteContextObj.Provider>
+          <RouteContextObj.Provider value={route}>{route.guard ? (route?.guard() == true ? '' : Navigate({ href: route.guard() })) : ''}{route.outlet()}</RouteContextObj.Provider>
         )) as JSX.FunctionElement
       }
     </Show>
@@ -155,6 +155,7 @@ export type RouteProps = {
   path: string | string[];
   children?: JSX.Element;
   data?: RouteDataFunc;
+  guard?: Accessor<void>;
 } & (
   | {
       element?: never;
@@ -182,7 +183,7 @@ export const Outlet = () => {
     <Show when={route.child}>
       {
         ((child: any) => (
-          <RouteContextObj.Provider value={child}>{child.outlet()}</RouteContextObj.Provider>
+          <RouteContextObj.Provider value={child}>{child.guard ? child?.guard() == true ? '' : Navigate({ href: child.guard() }) : ''}{child.outlet()}</RouteContextObj.Provider>
         )) as JSX.FunctionElement
       }
     </Show>
@@ -209,7 +210,7 @@ export function A(props: AnchorProps) {
     if (to_ === undefined) return false;
     const path = normalizePath(to_.split(/[?#]/, 1)[0]).toLowerCase();
     const loc = normalizePath(location.pathname).toLowerCase();
-    return props.end ? path === loc : loc.startsWith(path);
+    return props?.children ? path === loc : loc.startsWith(path);
   });
 
   return (
@@ -229,7 +230,8 @@ export function A(props: AnchorProps) {
   );
 }
 // deprecated alias exports
-export { A as Link, A as NavLink, AnchorProps as LinkProps, AnchorProps as NavLinkProps };
+export { A as Link, A as NavLink };
+export type { AnchorProps as LinkProps, AnchorProps as NavLinkProps };
 export interface NavigateProps {
   href: ((args: { navigate: Navigator; location: Location }) => string) | string;
   state?: unknown;

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -499,7 +499,7 @@ export function createRouteContext(
   const { pattern, element: outlet, preload, data } = match().route;
   const path = createMemo(() => match().path);
   const params = createMemoObject(() => match().params);
-
+  const guard = match().route.key?.guard;
   preload && preload();
 
   const route: RouteContext = {
@@ -510,6 +510,7 @@ export function createRouteContext(
     },
     path,
     params,
+    guard:guard,
     data: parent.data,
     outlet,
     resolvePath(to: string) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Component, JSX } from "solid-js";
+import { Accessor, Component, JSX } from "solid-js";
 
 export type Params = Record<string, string>;
 
@@ -56,6 +56,7 @@ export type RouteDataFunc<T = unknown, R = unknown> = (args: RouteDataFuncArgs<T
 export type RouteDefinition = {
   path: string | string[];
   data?: RouteDataFunc;
+  preload?: any;
   children?: RouteDefinition | RouteDefinition[];
 } & (
   | {
@@ -86,7 +87,7 @@ export interface OutputMatch {
 }
 
 export interface Route {
-  key: unknown;
+  key: any,
   originalPath: string;
   pattern: string;
   element: () => JSX.Element;
@@ -95,13 +96,17 @@ export interface Route {
   matcher: (location: string) => PathMatch | null;
 }
 
+export interface key_guard {
+  guard?: Accessor<string | false>
+}
+
 export interface Branch {
   routes: Route[];
   score: number;
   matcher: (location: string) => RouteMatch[] | null;
 }
 
-export interface RouteContext {
+export interface RouteContext extends key_guard {
   parent?: RouteContext;
   child?: RouteContext;
   data?: unknown;


### PR DESCRIPTION
sorry last time i sync without thinking about warning.

Here is again

### Guard

When notLogin(in below) is true that mean it will not do anything but if it is string it will redirect to the string that we get in return.

```js
const notLogin: Accessor<string | true> = createMemo(() => {
  if (unwrap(LoginService.get().login) != false) { return '/' }
  return true;
});
const App: Component = () => {
  return (
    <>
      <Router>
        <Routes>
          <Route path='/' component={Public_Layout}>
            <Route path='' component={HomePage} />
            <Route path='login/' guard={notLogin} component={Login_Page} />
            <Route path='register/' guard={notLogin} component={RegisterPage} />
          </Route>
        </Routes>
      </Router>
    </>
  );
};
```

Also there is issue i think


```js const App: Component = () => {
  return (
    <>
      <Router>
        <Routes>
          <Route path='/' component={Public_Layout}>
            <Route path='' component={HomePage} />//this came activeclass for login path
           <Route path='login/' guard={notLogin} component={Login_Page} />//this need only activeclass
            <Route path='register/' guard={notLogin} component={RegisterPage} />
          </Route>
        </Routes>
      </Router>
    </>
  );
};
```

for resolve this issue.
change

```js
    return props ? path === loc : loc.startsWith(path);
```
to  2 options
first 
```js
    return props?.children ? path === loc : loc.startsWith(path);
```

second that is kind of cutting thing I think so. 
```js
    return path === loc;
```

i don't found any use of it but may be there are uses that i don't know about it.

Also You are free for any edit and I feel this feature is necessary.