### PR TITLE
fix useMatch doesn't return match

### DIFF
--- a/src/routing.ts
+++ b/src/routing.ts
@@ -84,9 +84,12 @@ export const useMatch = (path: () => string) => {
   const matchers = createMemo(() =>
     expandOptionals(path()).map((path) => createMatcher(path))
   );
-  return createMemo(() =>
-    matchers().some((matcher) => matcher(location.pathname))
-  );
+  return createMemo(() => {
+    for (const matcher of matchers()) {
+      const match = matcher(location.pathname)
+      if (match) return match
+    }
+  });
 };
 
 export const useParams = <T extends Params>() => useRoute().params as T;


### PR DESCRIPTION
I accidentally broke `useMatch` in this pull request https://github.com/solidjs/solid-router/commit/502d188e55b63140afd7009594b32ce15564cf70