### PR TITLE
Segment validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,42 @@ The colon indicates that `id` can be any string, and as long as the URL fits tha
 
 You can then access that `id` from within a route component with `useParams`:
 
+---
+
+Each segment of the path can be validated using `SegmentValidator`.
+This allows for more complex routing descriptions than just checking the presence of a segment.
+
+```tsx
+import {lazy} from "solid-js";
+import {Routes, Route} from "@solidjs/router"
+import {SegmentValidators} from "./types";
+
+const Users = lazy(() => import("./pages/Users"));
+const User = lazy(() => import("./pages/User"));
+const Home = lazy(() => import("./pages/Home"));
+
+const validators: SegmentValidators = {
+  id: (v: string) => /^\d+$/.test(v), // only allow numbers
+  withHtmlExtension: (v: string) => /\.html$/.test(v) // We want an `*.html` extension
+}
+
+export default function App() {
+  return <>
+    <h1>My Site with Lots of Pages</h1>
+    <Routes>
+      <Route path="/users/~id/~withHtmlExtension" component={User} segmentValidators={validators}/>
+    </Routes>
+  </>
+}
+```
+
+Here the `~` denotes that the segment should be validated against the `id` validator.
+So in this example:
+
+- `/users/123/contact.html` would match,
+- `/users/123/about.html` would match,
+- `/users/me/contact.html` would not match (`~id` is not a number),
+- `/users/123/contact` would not match (`~withHtmlExtension` is missing `.html`).
 
 ```jsx
 //async fetching function

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A router lets you change your view based on the URL in the browser. This allows your "single-page" application to simulate a traditional multipage site. To use Solid Router, you specify components called Routes that depend on the value of the URL (the "path"), and the router handles the mechanism of swapping them in and out.
 
-Solid Router is a universal router for SolidJS - it works whether you're rendering on the client or on the server. It was inspired by and combines paradigms of React Router and the Ember Router. Routes can be defined directly in your app's template using JSX, but you can also pass your route configuration directly as an object. It also supports nested routing, so navigation can change a part of a component, rather than completely replacing it. 
+Solid Router is a universal router for SolidJS - it works whether you're rendering on the client or on the server. It was inspired by and combines paradigms of React Router and the Ember Router. Routes can be defined directly in your app's template using JSX, but you can also pass your route configuration directly as an object. It also supports nested routing, so navigation can change a part of a component, rather than completely replacing it.
 
 It supports all of Solid's SSR methods and has Solid's transitions baked in, so use it freely with suspense, resources, and lazy components. Solid Router also allows you to define a data function that loads parallel to the routes ([render-as-you-fetch](https://epicreact.dev/render-as-you-fetch/)).
 
@@ -16,8 +16,8 @@ It supports all of Solid's SSR methods and has Solid's transitions baked in, so 
 - [Create Links to Your Routes](#create-links-to-your-routes)
 - [Dynamic Routes](#dynamic-routes)
 - [Data Functions](#data-functions)
-- [Nested Routes](#nested-routes) 
-- [Hash Mode Router](#hash-mode-router) 
+- [Nested Routes](#nested-routes)
+- [Hash Mode Router](#hash-mode-router)
 - [Config Based Routing](#config-based-routing)
 - [Router Primitives](#router-primitives)
   - [useParams](#useparams)
@@ -63,17 +63,16 @@ Solid Router allows you to configure your routes using JSX:
 
 1. Use the `Routes` component to specify where the routes should appear in your app.
 
-
 ```jsx
 import { Routes, Route } from "@solidjs/router"
 
 export default function App() {
   return <>
-    <h1>My Site with Lots of Pages</h1>
+      <h1>My Site with Lots of Pages</h1>
     <Routes>
 
     </Routes>
-  </>
+    </>
 }
 ```
 
@@ -87,13 +86,13 @@ import Users from "./pages/Users"
 
 export default function App() {
   return <>
-    <h1>My Site with Lots of Pages</h1>
-    <Routes>
-      <Route path="/users" component={Users} />
-      <Route path="/" component={Home} />
-      <Route path="/about" element={<div>This site was made with Solid</div>} />
-    </Routes>
-  </>
+      <h1>My Site with Lots of Pages</h1>
+      <Routes>
+        <Route path="/users" component={Users} />
+        <Route path="/" component={Home} />
+        <Route path="/about" element={<div>This site was made with Solid</div>} />
+      </Routes>
+    </>
 }
 ```
 
@@ -109,13 +108,13 @@ const Home = lazy(() => import("./pages/Home"));
 
 export default function App() {
   return <>
-    <h1>My Site with Lots of Pages</h1>
-    <Routes>
-      <Route path="/users" component={Users} />
-      <Route path="/" component={Home} />
-      <Route path="/about" element={<div>This site was made with Solid</div>} />
-    </Routes>
-  </>
+      <h1>My Site with Lots of Pages</h1>
+      <Routes>
+        <Route path="/users" component={Users} />
+        <Route path="/" component={Home} />
+        <Route path="/about" element={<div>This site was made with Solid</div>} />
+      </Routes>
+    </>
 }
 ```
 
@@ -131,17 +130,17 @@ const Home = lazy(() => import("./pages/Home"));
 
 export default function App() {
   return <>
-    <h1>My Site with Lots of Pages</h1>
-    <nav>
-      <A href="/about">About</A>
-      <A href="/">Home</A>
-    </nav>
-    <Routes>
-      <Route path="/users" component={Users} />
-      <Route path="/" component={Home} />
-      <Route path="/about" element={<div>This site was made with Solid</div>} />
-    </Routes>
-  </>
+      <h1>My Site with Lots of Pages</h1>
+      <nav>
+        <A href="/about">About</A>
+        <A href="/">Home</A>
+      </nav>
+      <Routes>
+        <Route path="/users" component={Users} />
+        <Route path="/" component={Home} />
+        <Route path="/about" element={<div>This site was made with Solid</div>} />
+      </Routes>
+    </>
 }
 ```
 
@@ -163,7 +162,7 @@ Solid Router provides a `Navigate` component that works similarly to `A`, but it
 
 ```jsx
 function getPath ({navigate, location}) {
-  //navigate is the result of calling useNavigate(); location is the result of calling useLocation(). 
+  //navigate is the result of calling useNavigate(); location is the result of calling useLocation().
   //You can use those to dynamically determine a path to navigate to
   return "/some-path";
 }
@@ -174,7 +173,7 @@ function getPath ({navigate, location}) {
 
 ## Dynamic Routes
 
-If you don't know the path ahead of time, you might want to treat part of the path as a flexible parameter that is passed on to the component. 
+If you don't know the path ahead of time, you might want to treat part of the path as a flexible parameter that is passed on to the component.
 
 ```jsx
 import { lazy } from "solid-js";
@@ -185,14 +184,14 @@ const Home = lazy(() => import("./pages/Home"));
 
 export default function App() {
   return <>
-    <h1>My Site with Lots of Pages</h1>
-    <Routes>
-      <Route path="/users" component={Users} />
-      <Route path="/users/:id" component={User} />
-      <Route path="/" component={Home} />
-      <Route path="/about" element={<div>This site was made with Solid</div>} />
-    </Routes>
-  </>
+      <h1>My Site with Lots of Pages</h1>
+      <Routes>
+        <Route path="/users" component={Users} />
+        <Route path="/users/:id" component={User} />
+        <Route path="/" component={Home} />
+        <Route path="/about" element={<div>This site was made with Solid</div>} />
+      </Routes>
+    </>
 }
 ```
 
@@ -202,8 +201,8 @@ You can then access that `id` from within a route component with `useParams`:
 
 ---
 
-Each segment of the path can be validated using `SegmentValidator`.
-This allows for more complex routing descriptions than just checking the presence of a segment.
+Each path parameter can be validated using a `MatchFilter`.
+This allows for more complex routing descriptions than just checking the presence of a parameter.
 
 ```tsx
 import {lazy} from "solid-js";
@@ -214,30 +213,32 @@ const Users = lazy(() => import("./pages/Users"));
 const User = lazy(() => import("./pages/User"));
 const Home = lazy(() => import("./pages/Home"));
 
-const validators: SegmentValidators = {
-  id: (v: string) => /^\d+$/.test(v), // only allow numbers
-  withHtmlExtension: (v: string) => /\.html$/.test(v) // We want an `*.html` extension
+const filters: MatchFilters = {
+  parent: ['mom', 'dad'], // allow enum values
+  id: /^\d+$/, // only allow numbers
+  withHtmlExtension: (v: string) => v.length > 5 && v.endsWith('.html') // we want an `*.html` extension
 }
 
 export default function App() {
   return <>
-    <h1>My Site with Lots of Pages</h1>
-    <Routes>
-      <Route path="/users/:id/:withHtmlExtension" component={User} segmentValidators={validators}/>
-    </Routes>
-  </>
+      <h1>My Site with Lots of Pages</h1>
+      <Routes>
+      <Route path="/users/:parent/:id/:withHtmlExtension" component={User} matchFilters={filters}/>
+      </Routes>
+    </>
 }
 ```
 
-Here, we have added the `segmentValidators` prop. This allows us to validate the `id` and `withHtmlExtension` segments against the functions defined in `validators`.
+Here, we have added the `matchFilters` prop. This allows us to validate the `parent`, `id` and `withHtmlExtension` parameters against the filters defined in `filters`.
 If the validation fails, the route will not match.
 
 So in this example:
 
-- `/users/123/contact.html` would match,
-- `/users/123/about.html` would match,
-- `/users/me/contact.html` would not match `:id` is not a number,
-- `/users/123/contact` would not match `:withHtmlExtension` is missing `.html`.
+- `/users/mom/123/contact.html` would match,
+- `/users/dad/123/about.html` would match,
+- `/users/aunt/123/contact.html` would not match as `:parent` is not 'mom' or 'dad',
+- `/users/mom/me/contact.html` would not match as `:id` is not a number,
+- `/users/dad/123/contact` would not match as `:withHtmlExtension` is missing `.html`.
 
 ---
 
@@ -290,12 +291,10 @@ Routes also support defining multiple paths using an array. This allows a route 
 <Route path={["login", "register"]} component={Login}/>
 ```
 
-
 ## Data Functions
 In the [above example](#dynamic-routes), the User component is lazy-loaded and then the data is fetched. With route data functions, we can instead start fetching the data parallel to loading the route, so we can use the data as soon as possible.
 
-To do this, create a function that fetches and returns the data using `createResource`. Then pass that function to the `data` prop of the `Route` component. 
-
+To do this, create a function that fetches and returns the data using `createResource`. Then pass that function to the `data` prop of the `Route` component.
 
 ```js
 import { lazy } from "solid-js";
@@ -339,7 +338,7 @@ A common pattern is to export the data function that corresponds to a route in a
 ```js
 import { lazy } from "solid-js";
 import { Route } from "@solidjs/router";
-import { fetchUser } ... 
+import { fetchUser } ...
 import UserData from "./pages/users/[id].data.js";
 const User = lazy(() => import("/pages/users/[id].js"));
 
@@ -381,15 +380,14 @@ Only leaf Route nodes (innermost `Route` components) are given a route. If you w
 
 You can also take advantage of nesting by adding a parent element with an `<Outlet/>`.
 ```jsx
-
 import { Outlet } from "@solidjs/router";
 
 function PageWrapper () {
   return <div>
-    <h1> We love our users! </h1>
+      <h1> We love our users! </h1>
     <Outlet/>
-    <A href="/">Back Home</A>
-  </div>
+      <A href="/">Back Home</A>
+    </div>
 }
 
 <Route path="/users" component={PageWrapper}>
@@ -409,7 +407,7 @@ You can nest indefinitely - just remember that only leaf nodes will become their
 </Route>
 ```
 
-If you declare a `data` function on a parent and a child, the result of the parent's data function will be passed to the child's data function as the `data` property of the argument, as described in the last section. This works even if it isn't a direct child, because by default every route forwards its parent's data. 
+If you declare a `data` function on a parent and a child, the result of the parent's data function will be passed to the child's data function as the `data` property of the argument, as described in the last section. This works even if it isn't a direct child, because by default every route forwards its parent's data.
 
 ## Hash Mode Router
 
@@ -600,11 +598,9 @@ useBeforeLeave((e: BeforeLeaveEventArgs) => {
     setTimeout(() => {
       if (window.confirm("Discard unsaved changes - are you sure?")) {
         // user wants to proceed anyway so retry with force=true
-        e.retry(true); 
+        e.retry(true);
       }
     }, 100);
   }
 });
 ```
-
-

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ This allows for more complex routing descriptions than just checking the presenc
 ```tsx
 import {lazy} from "solid-js";
 import {Routes, Route} from "@solidjs/router"
-import {SegmentValidators} from "./types";
+import type {SegmentValidators} from "./types";
 
 const Users = lazy(() => import("./pages/Users"));
 const User = lazy(() => import("./pages/User"));
@@ -223,19 +223,23 @@ export default function App() {
   return <>
     <h1>My Site with Lots of Pages</h1>
     <Routes>
-      <Route path="/users/~id/~withHtmlExtension" component={User} segmentValidators={validators}/>
+      <Route path="/users/:id/:withHtmlExtension" component={User} segmentValidators={validators}/>
     </Routes>
   </>
 }
 ```
 
-Here the `~` denotes that the segment should be validated against the `id` validator.
+Here, we have added the `segmentValidators` prop. This allows us to validate the `id` and `withHtmlExtension` segments against the functions defined in `validators`.
+If the validation fails, the route will not match.
+
 So in this example:
 
 - `/users/123/contact.html` would match,
 - `/users/123/about.html` would match,
-- `/users/me/contact.html` would not match (`~id` is not a number),
-- `/users/123/contact` would not match (`~withHtmlExtension` is missing `.html`).
+- `/users/me/contact.html` would not match `:id` is not a number,
+- `/users/123/contact` would not match `:withHtmlExtension` is missing `.html`.
+
+---
 
 ```jsx
 //async fetching function

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -21,12 +21,12 @@ import {
 import type {
   Location,
   LocationChangeSignal,
+  MatchFilters,
   Navigator,
   RouteContext,
   RouteDataFunc,
   RouteDefinition,
-  RouterIntegration,
-  SegmentValidators
+  RouterIntegration
 } from "./types";
 import { joinPaths, normalizePath } from "./utils";
 
@@ -152,11 +152,11 @@ export const useRoutes = (routes: RouteDefinition | RouteDefinition[], base?: st
   return () => <Routes base={base}>{routes as any}</Routes>;
 };
 
-export type RouteProps = {
-  path: string | string[];
+export type RouteProps<S extends string> = {
+  path: S | S[];
   children?: JSX.Element;
   data?: RouteDataFunc;
-  segmentValidators?: SegmentValidators;
+  matchFilters?: MatchFilters<S>;
 } & (
   | {
       element?: never;
@@ -169,7 +169,7 @@ export type RouteProps = {
     }
 );
 
-export const Route = (props: RouteProps) => {
+export const Route = <S extends string>(props: RouteProps<S>) => {
   const childRoutes = children(() => props.children);
   return mergeProps(props, {
     get children() {
@@ -202,7 +202,14 @@ export interface AnchorProps extends Omit<JSX.AnchorHTMLAttributes<HTMLAnchorEle
 }
 export function A(props: AnchorProps) {
   props = mergeProps({ inactiveClass: "inactive", activeClass: "active" }, props);
-  const [, rest] = splitProps(props, ["href", "state", "class", "activeClass", "inactiveClass", "end"]);
+  const [, rest] = splitProps(props, [
+    "href",
+    "state",
+    "class",
+    "activeClass",
+    "inactiveClass",
+    "end"
+  ]);
   const to = useResolvedPath(() => props.href);
   const href = useHref(to);
   const location = useLocation();

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -25,7 +25,8 @@ import type {
   RouteContext,
   RouteDataFunc,
   RouteDefinition,
-  RouterIntegration
+  RouterIntegration,
+  SegmentValidators
 } from "./types";
 import { joinPaths, normalizePath } from "./utils";
 
@@ -155,6 +156,7 @@ export type RouteProps = {
   path: string | string[];
   children?: JSX.Element;
   data?: RouteDataFunc;
+  segmentValidators?: SegmentValidators;
 } & (
   | {
       element?: never;

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -21,6 +21,7 @@ import type {
   Location,
   LocationChange,
   LocationChangeSignal,
+  MatchFilters,
   NavigateOptions,
   Navigator,
   Params,
@@ -32,7 +33,6 @@ import type {
   RouterContext,
   RouterIntegration,
   RouterOutput,
-  SegmentValidators,
   SetParams
 } from "./types";
 import {
@@ -79,15 +79,15 @@ export const useNavigate = () => useRouter().navigatorFactory();
 export const useLocation = <S = unknown>() => useRouter().location as Location<S>;
 export const useIsRouting = () => useRouter().isRouting;
 
-export const useMatch = (path: () => string, segmentValidators?: SegmentValidators) => {
+export const useMatch = <S extends string>(path: () => S, matchFilters?: MatchFilters<S>) => {
   const location = useLocation();
   const matchers = createMemo(() =>
-    expandOptionals(path()).map((path) => createMatcher(path, undefined, segmentValidators))
+    expandOptionals(path()).map(path => createMatcher(path, undefined, matchFilters))
   );
   return createMemo(() => {
     for (const matcher of matchers()) {
-      const match = matcher(location.pathname)
-      if (match) return match
+      const match = matcher(location.pathname);
+      if (match) return match;
     }
   });
 };
@@ -105,13 +105,21 @@ export const useSearchParams = <T extends Params>(): [
   const navigate = useNavigate();
   const setSearchParams = (params: SetParams, options?: Partial<NavigateOptions>) => {
     const searchString = untrack(() => mergeSearchString(location.search, params));
-    navigate(location.pathname + searchString + location.hash, { scroll: false, resolve: false, ...options });
+    navigate(location.pathname + searchString + location.hash, {
+      scroll: false,
+      resolve: false,
+      ...options
+    });
   };
   return [location.query as T, setSearchParams];
 };
 
 export const useBeforeLeave = (listener: (e: BeforeLeaveEventArgs) => void) => {
-  const s = useRouter().beforeLeave.subscribe({ listener, location: useLocation(), navigate: useNavigate() });
+  const s = useRouter().beforeLeave.subscribe({
+    listener,
+    location: useLocation(),
+    navigate: useNavigate()
+  });
   onCleanup(s);
 };
 
@@ -128,11 +136,11 @@ export function createRoutes(
     element: component
       ? () => createComponent(component, {})
       : () => {
-        const { element } = routeDef;
-        return element === undefined && fallback
-          ? createComponent(fallback, {})
-          : (element as JSX.Element);
-      },
+          const { element } = routeDef;
+          return element === undefined && fallback
+            ? createComponent(fallback, {})
+            : (element as JSX.Element);
+        },
     preload: routeDef.component
       ? (component as MaybePreloadableComponent).preload
       : routeDef.preload,
@@ -147,7 +155,7 @@ export function createRoutes(
         ...shared,
         originalPath,
         pattern,
-        matcher: createMatcher(pattern, !isLeaf, routeDef.segmentValidators)
+        matcher: createMatcher(pattern, !isLeaf, routeDef.matchFilters)
       });
     }
     return acc;
@@ -195,7 +203,7 @@ export function createBranches(
       const routes = createRoutes(def, base, fallback);
       for (const route of routes) {
         stack.push(route);
-        const isEmptyArray = Array.isArray(def.children) && def.children.length === 0
+        const isEmptyArray = Array.isArray(def.children) && def.children.length === 0;
         if (def.children && !isEmptyArray) {
           createBranches(def.children, route.pattern, fallback, stack, branches);
         } else {
@@ -284,9 +292,9 @@ export function createRouterContext(
   const output =
     isServer && out
       ? (Object.assign(out, {
-        matches: [],
-        url: undefined
-      }) as RouterOutput)
+          matches: [],
+          url: undefined
+        }) as RouterOutput)
       : undefined;
 
   if (basePath === undefined) {

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -32,6 +32,7 @@ import type {
   RouterContext,
   RouterIntegration,
   RouterOutput,
+  SegmentValidators,
   SetParams
 } from "./types";
 import {
@@ -78,10 +79,10 @@ export const useNavigate = () => useRouter().navigatorFactory();
 export const useLocation = <S = unknown>() => useRouter().location as Location<S>;
 export const useIsRouting = () => useRouter().isRouting;
 
-export const useMatch = (path: () => string) => {
+export const useMatch = (path: () => string, segmentValidators?: SegmentValidators) => {
   const location = useLocation();
   const matchers = createMemo(() =>
-    expandOptionals(path()).map((path) => createMatcher(path))
+    expandOptionals(path()).map((path) => createMatcher(path, undefined, segmentValidators))
   );
   return createMemo(() => {
     for (const matcher of matchers()) {
@@ -146,7 +147,7 @@ export function createRoutes(
         ...shared,
         originalPath,
         pattern,
-        matcher: createMatcher(pattern, !isLeaf)
+        matcher: createMatcher(pattern, !isLeaf, routeDef.segmentValidators)
       });
     }
     return acc;

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,7 @@ export type RouteDataFunc<T = unknown, R = unknown> = (args: RouteDataFuncArgs<T
 
 export type RouteDefinition = {
   path: string | string[];
+  segmentValidators?: SegmentValidators;
   data?: RouteDataFunc;
   children?: RouteDefinition | RouteDefinition[];
 } & (
@@ -68,6 +69,10 @@ export type RouteDefinition = {
       preload?: () => void;
     }
 );
+
+export type ValidatorFunc = (segment: string) => boolean;
+
+export type SegmentValidators = Record<string, ValidatorFunc>;
 
 export interface PathMatch {
   params: Params;
@@ -93,6 +98,7 @@ export interface Route {
   preload?: () => void;
   data?: RouteDataFunc;
   matcher: (location: string) => PathMatch | null;
+  segmentValidators?: SegmentValidators;
 }
 
 export interface Branch {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,16 +65,12 @@ export function createMatcher(path: string, partial?: boolean, segmentValidators
     for (let i = 0; i < len; i++) {
       const segment = segments[i];
       const locSegment = locSegments[i];
-      const key = [":", "~"].includes(segment[0]) ? segment.slice(1) : segment;
+      const key = segment[0] === ":" ? segment.slice(1) : segment;
 
-      if (segment[0] === ":") {
+      if (segment[0] === ":" && (segmentValidators === undefined || segmentValidators && segmentValidators[key] === undefined)) {
         match.params[key] = locSegment;
-      } else if (
-        segment[0] === "~" &&
-        segmentValidators &&
-        typeof segmentValidators[key] === "function" &&
-        segmentValidators[key](locSegment)
-      ) {
+      } else if (segment[0] === ":" && segmentValidators &&
+        typeof segmentValidators[key] === "function" && segmentValidators[key](locSegment)) {
         match.params[key] = locSegment;
       } else if (segment.localeCompare(locSegment, undefined, { sensitivity: "base" }) !== 0) {
         return null;

--- a/test/route.spec.ts
+++ b/test/route.spec.ts
@@ -157,6 +157,20 @@ describe("createRoutes should", () => {
         all: "BaR/sOlId"
       });
     });
+
+    test(`validate segment using validators`, () => {
+      const routeDef = {
+        path: "foo/~number/bar/~withHtmlExtension",
+        segmentValidators: {
+          number: (v: string) => /^\d+$/.test(v),
+          withHtmlExtension: (v: string) => /\.html$/.test(v)
+        }
+      };
+      const route = createRoute(routeDef);
+      const { path } = route.matcher("/foo/123/bar/solid.html")!;
+      expect(path).toBe("/foo/123/bar/solid.html");
+    });
+
   });
 
   describe(`expand optional parameters`, () => {

--- a/test/route.spec.ts
+++ b/test/route.spec.ts
@@ -160,7 +160,7 @@ describe("createRoutes should", () => {
 
     test(`validate segment using validators`, () => {
       const routeDef = {
-        path: "foo/~number/bar/~withHtmlExtension",
+        path: "foo/:number/bar/:withHtmlExtension",
         segmentValidators: {
           number: (v: string) => /^\d+$/.test(v),
           withHtmlExtension: (v: string) => /\.html$/.test(v)

--- a/test/route.spec.ts
+++ b/test/route.spec.ts
@@ -1,4 +1,5 @@
 import { createBranch, createBranches, createRoutes } from "../src/routing";
+import type { RouteDefinition } from "../src";
 
 const createRoute = (...args: Parameters<typeof createRoutes>) => createRoutes(...args)[0];
 
@@ -158,17 +159,18 @@ describe("createRoutes should", () => {
       });
     });
 
-    test(`validate segment using validators`, () => {
-      const routeDef = {
+    test(`validate path using match filters`, () => {
+      const routeDef: RouteDefinition = {
         path: "foo/:number/bar/:withHtmlExtension",
-        segmentValidators: {
+        matchFilters: {
           number: (v: string) => /^\d+$/.test(v),
           withHtmlExtension: (v: string) => /\.html$/.test(v)
         }
       };
       const route = createRoute(routeDef);
-      const { path } = route.matcher("/foo/123/bar/solid.html")!;
-      expect(path).toBe("/foo/123/bar/solid.html");
+      const match = route.matcher("/foo/123/bar/solid.html")!;
+      expect(match).not.toBeNull();
+      expect(match.path).toBe("/foo/123/bar/solid.html");
     });
 
   });

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -1,0 +1,111 @@
+import { RouteProps } from "../src/components";
+import { useMatch } from "../src/routing";
+import { MatchFilters } from "../src/types";
+import { createMatcher } from "../src/utils";
+
+// mock route type
+const Route = <S extends string>(props: RouteProps<S>) => {};
+
+describe("Type checking on various route definitions", () => {
+  test("Does not check implementations", () => {});
+
+  // Matchfilters on createMatcher are typechecked
+  () => {
+    const _matcher = createMatcher("/:parent/:birthDate/*extras", undefined, {
+      parent: ["mom", "dad"],
+      birthDate: /^\d{4}$/,
+      extras: s => s.length > 4
+    });
+
+    const _invalid = createMatcher("/:unknown", undefined, {
+      // @ts-expect-error 'first' is not a path paramter
+      first: /^\d+$/
+    });
+
+    // allow disabling typechecks
+    const _asAny = createMatcher("/:unknown" as any, undefined, {
+      whatever: /^\d+$/
+    });
+  };
+
+  // Matchfilters on useMatch are typechecked
+  () => {
+    const _match = useMatch(() => "/:parent/:birthDate/*extras", {
+      parent: ["mom", "dad"],
+      birthDate: /^\d{4}$/,
+      extras: s => s.length > 4
+    });
+
+    const _invalid = useMatch(() => "/:unknown", {
+      // @ts-expect-error 'first' is not a path paramter
+      first: /^\d+$/
+    });
+
+    // allow disabling typechecks
+    const _asAny = useMatch("/:unknown" as any, {
+      whatever: /^\d+$/
+    });
+  };
+
+  // Matchfilters on a Route are typechecked
+  () => {
+    const _route = Route({
+      path: "/:parent/:birthDate/*extras",
+      matchFilters: {
+        parent: ["mom", "dad"],
+        birthDate: /^\d{4}$/,
+        extras: s => s.length > 4
+      }
+    });
+
+    const _invalid = Route({
+      path: "/:unknown",
+      matchFilters: {
+        // @ts-expect-error 'first' is not a path paramter
+        first: /^\d+$/
+      }
+    });
+
+    // allow disabling typechecks
+    const _asAny = Route({
+      path: "/:unknown" as any,
+      matchFilters: {
+        whatever: /^\d+$/
+      }
+    });
+
+    const _multiple = Route({
+      path: ["cars/:id/:plate", "vans/:id"],
+      matchFilters: {
+        id: /^\d+$/,
+        plate: /^\d{2}-\w{3}-\d{2}$/,
+        // @ts-expect-error 'something' is not a parameter in either path
+        something: s => true
+      }
+    });
+
+    // cannot typecheck filters ahead of time, so 'any' is assumed
+    const matchFilters: MatchFilters = {
+      id: /^\d+$/,
+      other: s => s.length > 4
+    };
+
+    const _usingPredefined = Route({
+      path: "/:id",
+      matchFilters
+    });
+
+    // enable typechecking by specifying variables
+    const checkedMatchFilters: MatchFilters<":id"> = {
+      id: /^\d+$/,
+      // @ts-expect-error 'other' is not a defined paramter
+      other: s => s.length > 4
+    };
+
+    const _usingPredefinedTypesafe = Route({
+      path: "/:product",
+      // @ts-expect-error 'id' is not a defined paramter
+      checkedMatchFilters
+    });
+  };
+});

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -147,7 +147,7 @@ describe("createMatcher should", () => {
   });
 
   test("validate each segment with provided validators", () => {
-    const matcher = createMatcher("/~parent/~birthYear", undefined, {
+    const matcher = createMatcher("/:parent/:birthYear", undefined, {
       parent: v => ["dad", "mum"].includes(v),
       birthYear: v => /^\d+$/.test(v)
     });

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -145,6 +145,36 @@ describe("createMatcher should", () => {
     expect(match!.path).toBe(expected.path);
     expect(match!.params).toEqual(expected.params);
   });
+
+  test("validate each segment with provided validators", () => {
+    const matcher = createMatcher("/~parent/~birthYear", undefined, {
+      parent: v => ["dad", "mum"].includes(v),
+      birthYear: v => /^\d+$/.test(v)
+    });
+
+    const expected1 = { path: "/dad/1943", params: { parent: "dad", birthYear: "1943" } };
+
+    const match1 = matcher("/dad/1943");
+    expect(match1).not.toBe(null);
+    expect(match1!.path).toBe(expected1.path);
+    expect(match1!.params).toEqual(expected1.params);
+
+    const expected2 = { path: "/mum/1954", params: { parent: "mum", birthYear: "1954" } };
+
+    const match2 = matcher("/mum/1954");
+    expect(match2).not.toBe(null);
+    expect(match2!.path).toBe(expected2.path);
+    expect(match2!.params).toEqual(expected2.params);
+
+    const match3 = matcher("/ant/twothousandtwentythree");
+    expect(match3).toBe(null);
+
+    const match4 = matcher("/dad/mum");
+    expect(match4).toBe(null);
+
+    const match5 = matcher("/123/mum");
+    expect(match5).toBe(null);
+  });
 });
 
 describe("joinPaths should", () => {


### PR DESCRIPTION
Hi Ryan,

I have a need for the project I'm currently working on, to have complex path matching rules. To target different routes based on the path.

The mechanism in place allow to match on the shape of the paths. But it's impossible to have 2 different routes for theses 2 paths (path => route which I would express):

- `/product/soap.html` => `/product/:product_type`
- `/product/marvelous-soap-12345.html` => `/product/:product_slug`

I have implemented what I call `Segment Validators`. I would love to have your opinion on naming and ergonomics.

It's a function which is called to validate the segment value against the validator defined in user-land.

For example in a route definition:

- `:id` could be validated as a integer,
- `:controller` could either "product" or "cart", but nothing else,
- `:slug` could a complexe string that we would test against a regex.

I think this is great for the flexibility of the router, because this allows to have routes which share the same _shape_ `/seg1/seg2/seg3` but matching different routes. I stop here, I'm sure you've got the point.

Every previous tests is passing. I've added new ones for this evolution. And I tested in Solid Start, it works out-the-box when you add route definitions in `root.tsx`.

```tsx
const segmentValidators: SegmentValidators = {
    number: (v: string) => /^\d+$/.test(v),
    html: (v: string) => /\.html$/.test(v),
  };

<Routes>
  <Route
    path="/:number/:html"
    element={<Test />}
    segmentValidators={segmentValidators}
  />
  <FileRoutes />
</Routes>
```

I'd love your feedback one this.

Thanks,
Jérémy