### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ const [searchParams, setSearchParams] = useSearchParams();
 return (
   <div>
     <span>Page: {searchParams.page}</span>
-    <button onClick={() => setSearchParams({ page: searchParams.page + 1 })}>Next Page</button>
+    <button onClick={() => setSearchParams({ page: (parseInt(searchParams.page) || 0) + 1 })}>Next Page</button>
   </div>
 );
 ```


### PR DESCRIPTION
Fixed the handling of the searchParams return type and convert it from String to Number in order to increment it. Default to 0 if parameter not defined yet. The handling of the empty page String in the setSearchParams feels cleaner than initializing the page to 0, as the parameter is mostly used after the first page.