### PR TITLE
Add `exactActiveClass` to A component

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ export default function App() {
 }
 ```
 
-The `<A>` tag also has an `active` class if its href matches the current location, an `exactActive` class if its href matches the current location exactly and `inactive` class otherwise. **Note:** `active` and `exactActive` are mutually exclusive - there is no class merging! By default matching includes locations that are descendents (eg. href `/users` matches locations `/users` and `/users/123`). `exactActive` is particularly useful for links to the root route `/` which would match everything.
+The `<A>` tag also has an `active` class if its href matches the current location and `inactive` class otherwise. By providing the property `exactActiveClass`, you can opt in to a third state, which is `exactActive` and is set when the href matches the current location exactly.  **Note:** By default matching includes locations that are descendents (eg. href `/users` matches locations `/users` and `/users/123`). If no `exactActiveClass` property was provided, `active` class will be set for both partially and exactly matching routes.
 
 
 | prop     | type    | description                                                                                                                                                                              |
@@ -155,8 +155,8 @@ The `<A>` tag also has an `active` class if its href matches the current locatio
 | state    | unknown | [Push this value](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) to the history stack when navigating  |                                      |
 | inactiveClass | string  | The class to show when the link is inactive (when the current location doesn't match the link) |
 | activeClass | string | The class to show when the link is active, i.e. the current location _starts with_ `href`                                                                                                       |
-| exactActiveClass | string | The class to show when the link matches the `href` exactly                                                                                                        |
-| end  | boolean | If `true`, only considers the link to be active when the curent location matches the `href` exactly; if `false`, check if the current location _starts with_ `href` |
+| exactActiveClass | string or true | The class to show when the link matches the `href` exactly. If `true`, applies `exactActive` class and enables strict matching - i.e. `activeClass` will not apply for an exact match.
+| end  | boolean | **Deprecated** If `true`, only considers the link to be active when the curent location matches the `href` exactly; if `false`, check if the current location _starts with_  `href` - providing `exactActiveClass` overrides this behavior |                                                                                                    |
 
 ### The Navigate Component
 Solid Router provides a `Navigate` component that works similarly to `A`, but it will _immediately_ navigate to the provided path as soon as the component is rendered. It also uses the `href` prop, but you have the additional option of passing a function to `href` that returns a path to navigate to:

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ export default function App() {
 }
 ```
 
-The `<A>` tag also has an `active` class if its href matches the current location, and `inactive` otherwise. **Note:** By default matching includes locations that are descendents (eg. href `/users` matches locations `/users` and `/users/123`), use the boolean `end` prop to prevent matching these. This is particularly useful for links to the root route `/` which would match everything.
+The `<A>` tag also has an `active` class if its href matches the current location, an `exactActive` class if its href matches the current location exactly and `inactive` class otherwise. **Note:** `active` and `exactActive` are mutually exclusive - there is no class merging! By default matching includes locations that are descendents (eg. href `/users` matches locations `/users` and `/users/123`). `exactActive` is particularly useful for links to the root route `/` which would match everything.
 
 
 | prop     | type    | description                                                                                                                                                                              |
@@ -154,7 +154,8 @@ The `<A>` tag also has an `active` class if its href matches the current locatio
 | replace  | boolean | If true, don't add a new entry to the browser history. (By default, the new page will be added to the browser history, so pressing the back button will take you to the previous route.) |
 | state    | unknown | [Push this value](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) to the history stack when navigating  |                                      |
 | inactiveClass | string  | The class to show when the link is inactive (when the current location doesn't match the link) |
-| activeClass | string | The class to show when the link is active                                                                                                        |
+| activeClass | string | The class to show when the link is active, i.e. the current location _starts with_ `href`                                                                                                       |
+| exactActiveClass | string | The class to show when the link matches the `href` exactly                                                                                                        |
 | end  | boolean | If `true`, only considers the link to be active when the curent location matches the `href` exactly; if `false`, check if the current location _starts with_ `href` |
 
 ### The Navigate Component

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -236,12 +236,12 @@ export function A(props: AnchorProps) {
     return [loc.startsWith(path), path === loc];
   });
 
-  const isLooseActive = createMemo(() => matchedHref()[0])
-  const isExactActive = createMemo(() => matchedHref()[1] && Boolean(props.exactActiveClass))
+  const isLooseMatch = createMemo(() => matchedHref()[0])
+  const isExactMatch = createMemo(() => matchedHref()[1] && Boolean(props.exactActiveClass))
 
   // Remove together with `end` property
   // If end was provided return an exact match, else return loose match (as long as users don't opt in for new behavior)
-  const isActiveDeprecated = createMemo(() => props.end ? matchedHref()[1] : !props.exactActiveClass && isLooseActive())
+  const isActiveDeprecated = createMemo(() => props.end ? matchedHref()[1] : !props.exactActiveClass && isLooseMatch())
 
   return (
     <a
@@ -251,12 +251,12 @@ export function A(props: AnchorProps) {
       state={JSON.stringify(props.state)}
       classList={{
         ...(props.class && { [props.class]: true }),
-        [props.inactiveClass!]: !isLooseActive(),
-        [props.activeClass!]: isLooseActive() && !isExactActive() || isActiveDeprecated(),
-        ...(props.exactActiveClass && { [props.exactActiveClass === true ? 'exactActive' : props.exactActiveClass]: isExactActive() }),
+        [props.inactiveClass!]: !isLooseMatch(),
+        [props.activeClass!]: isLooseMatch() && !isExactMatch() || isActiveDeprecated(),
+        ...(props.exactActiveClass && { [props.exactActiveClass === true ? 'exactActive' : props.exactActiveClass]: isExactMatch() }),
         ...rest.classList
       }}
-      aria-current={isLooseActive() ? "page" : undefined}
+      aria-current={isLooseMatch() ? "page" : undefined}
     />
   );
 }


### PR DESCRIPTION
## The problem
With current design of the `A` component classes, there is one shortcoming:
An `A` component can be in one of three states: `inactive`, `active` and `exactActive`. But you cannot independently provide classes for each of the three since you have to choose between one of the two states `active` and `exactActive` by using the `end` property.

What this PR does is add the `exactActiveClass` prop which makes it so that you can provide classes for each of the three possible states. It also deprecates the `end` property.

## Considerations
Imo, treating `active` and `exactActive` as two distinct states is the wanted behavior because of a possible class pollution.

Simple example:
```
<A href="/main/nested" activeClass="text-white" exactActiveClass="text-red" />
```
With inclusive matching, this will generate an `a` element with class `text-white text-red`. It pollutes the space and also leads to class conflicts. A solution to make sure the `exactActive` classes are applied would be for the user to make them `important` but it's unintuitive and pollutes the class space even more.

Having this in mind, I think going for a stricter mutually exclusive distinction is the best way to go.
It does lead to duplication ( e.g. `activeClass="text-white text-lg" exactActiveClass="text-white text-xl"` ) but at least there is nothing unexpected going on in this scenario.

I'm open to suggestions and looking forward to feedback. Have a nice day

## Update
I've edited some of the original post to keep it a bit more concise. I went with a non-breaking implementation and one that is a bit more explicit than it was before. Mostly because of the added complexity of allowing `true` to just pass the `exactActiveClass` attribute. "3 distinct States" is opt-in.

It would now work like this (disregarding `inactive` class):
`<A href="/home" activeClass="text-white">Home</A>` will match both partially and exactly and class will be `text-white`

`<A href="/home" exactActiveClass>Home</A>` enables strict matching => class will either be `active` or `exactActive`

`<A href="/home" exactActiveClass="text-white">Home</A>` enables strict matching => class will either be `active` or `text-white`


This makes me think, wouldn't it be nice to have this same opt-in behavior for the other classes as well? Currently, there are `inactive` and `active` classes whether I need/want them or not. Would give a bit more control to users to have to opt-in first.

`<A href="/home" inactiveClass activeClass>Home</A>`

But I'll leave that for a different PR/time.