### PR TITLE
Remove / trimming on the end of href

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,10 +2,10 @@ import { createMemo, getOwner, runWithOwner } from "solid-js";
 import type { MatchFilter, MatchFilters, Params, PathMatch, Route, SetParams } from "./types";
 
 const hasSchemeRegex = /^(?:[a-z0-9]+:)?\/\//i;
-const trimPathRegex = /^\/+|\/+$/g;
+const trimPathRegex = /^\/+|(\/)\/+$/g;
 
 export function normalizePath(path: string, omitSlash: boolean = false) {
-  const s = path.replace(trimPathRegex, "");
+  const s = path.replace(trimPathRegex, "$1");
   return s ? (omitSlash || /^[?#]/.test(s) ? s : "/" + s) : "";
 }
 

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -241,7 +241,7 @@ describe("joinPaths should", () => {
   test.each([
     ["/foo", "", "/foo"],
     ["/foo/", "/", "/foo"],
-    ["/foo/", "bar/", "/foo/bar"]
+    ["/foo/", "bar/", "/foo/bar/"]
   ])(`strip trailing '/' (case '%s' and '%s' as '%s')`, (from, to, expected) => {
     const joined = joinPaths(from, to);
     expect(joined).toBe(expected);


### PR DESCRIPTION
### The Problem
When using the `<A>` component the href value gets striped of any '/' at the end. 
Example:
`<A href={"/users/"}`>Users</A>
becomes 
`<a href="/users">Users</a> `
in the html. This behaviour is irritating for developers especially since the route could handle links with '/' at the end just fine. This PR is changing the behaviour of the normalise function to correct the behaviour. 