### PR TITLE
fix anchor tags types to also allow undefined

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -198,12 +198,12 @@ export const Outlet = () => {
 
 export interface AnchorProps extends Omit<JSX.AnchorHTMLAttributes<HTMLAnchorElement>, "state"> {
   href: string;
-  replace?: boolean;
-  noScroll?: boolean;
-  state?: unknown;
-  inactiveClass?: string;
-  activeClass?: string;
-  end?: boolean;
+  replace?: boolean | undefined;
+  noScroll?: boolean | undefined;
+  state?: unknown | undefined;
+  inactiveClass?: string | undefined;
+  activeClass?: string | undefined;
+  end?: boolean | undefined;
 }
 export function A(props: AnchorProps) {
   props = mergeProps({ inactiveClass: "inactive", activeClass: "active" }, props);


### PR DESCRIPTION
this just adds undefined to all optional properties on the anchor component