### PR TITLE
fix(typescript): `RouteDataFuncArgs.data` incorrect type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export interface RouterIntegration {
 }
 
 export interface RouteDataFuncArgs<T = unknown> {
-  data: T extends RouteDataFunc ? ReturnType<T> : T;
+  data: T extends RouteDataFunc<infer _, infer R> ? R : T;
   params: Params;
   location: Location;
   navigate: Navigator;


### PR DESCRIPTION
Using `RouteDataFunc` without specifying any generic types results in `RouteDataFunc<unknown, unknown>`, which `RouteDataFunc<NotUnknown, unknown>` does not extend. See https://stackblitz.com/edit/solid-ssr-vite-pcbdkr?file=tsconfig.json,src%2Froutes%2Findex.tsx:

```
Expected 1 arguments, but got 0.(2554)
index.tsx(7, 25): An argument for 'args' was not provided.
```

Since `(args: RouteDataArgs<typeof routeData>) => (() => undefined) | (() => string)` does not extend `RouteDataFunc<unknown, unknown>`, the type is not `ReturnType<T>` but `T`.

This change makes it so that that case is properly handled and typed. I avoided using `any` but the change would otherwise be equivalent to:

```ts
  data: T extends RouteDataFunc<any> ? ReturnType<T> : T;
```