### PR TITLE
feat: extend useSearchParams hook

### DIFF
--- a/src/routing.ts
+++ b/src/routing.ts
@@ -99,10 +99,7 @@ export const useRouteData = <T>() => useRoute().data as MaybeReturnType<T>;
 
 export const useSearchParams = <T extends Params>(): [
   T,
-  (
-    params: SetParams | ((params: T) => SetParams),
-    options?: Partial<NavigateOptions>
-  ) => void
+  (params: SetParams | ((params: T) => SetParams), options?: Partial<NavigateOptions>) => void
 ] => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -146,11 +143,11 @@ export function createRoutes(
     element: component
       ? () => createComponent(component, {})
       : () => {
-        const { element } = routeDef;
-        return element === undefined && fallback
-          ? createComponent(fallback, {})
-          : (element as JSX.Element);
-      },
+          const { element } = routeDef;
+          return element === undefined && fallback
+            ? createComponent(fallback, {})
+            : (element as JSX.Element);
+        },
     preload: routeDef.component
       ? (component as MaybePreloadableComponent).preload
       : routeDef.preload,
@@ -302,9 +299,9 @@ export function createRouterContext(
   const output =
     isServer && out
       ? (Object.assign(out, {
-        matches: [],
-        url: undefined
-      }) as RouterOutput)
+          matches: [],
+          url: undefined
+        }) as RouterOutput)
       : undefined;
 
   if (basePath === undefined) {


### PR DESCRIPTION
feat: Enable passing a function to `setSearchParams` for dynamic search updates

This commit introduces a new enhancement to the `useSearchParams`  hook, allowing the `setSearchParams`  function to accept a callback function as an argument. By passing a function instead of a plain object to `setSearchParams` , developers can now perform dynamic search updates based on the current search parameters. The callback function receives the existing search parameters as its argument, and it should return an updated search parameters object. This feature enables more flexible and dynamic search functionality, empowering developers to easily handle complex search scenarios and update search parameters in a controlled manner.

https://github.com/solidjs/solid-router/issues/328


