### PR TITLE
feat: intent based route preloading

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -131,7 +131,8 @@ export const Routes = (props: RoutesProps) => {
               next[i - 1] || parentRoute,
               () => routeStates()[i + 1],
               () => matches()[i],
-              params
+              params,
+              branches
             );
           });
         }

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -18,6 +18,7 @@ import { createBeforeLeave } from "./lifecycle";
 import type {
   BeforeLeaveEventArgs,
   Branch,
+  LinkPreloadOpts,
   Location,
   LocationChange,
   LocationChangeSignal,
@@ -277,7 +278,9 @@ export function createRouterContext(
   integration?: RouterIntegration | LocationChangeSignal,
   base: string = "",
   data?: RouteDataFunc,
-  out?: object
+  out?: object,
+  preload?: LinkPreloadOpts["preload"],
+  preloadDelay?: LinkPreloadOpts["preloadDelay"]
 ): RouterContext {
   const {
     signal: [source, setSource],
@@ -543,7 +546,9 @@ export function createRouterContext(
     parsePath,
     navigatorFactory,
     beforeLeave,
-    preloadFactory
+    preloadFactory,
+    preload,
+    preloadDelay
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Component, JSX } from "solid-js";
+import { Accessor, Component, JSX } from "solid-js";
 
 export type Params = Record<string, string>;
 
@@ -129,6 +129,7 @@ export interface RouteContext {
   path: () => string;
   outlet: () => JSX.Element;
   resolvePath(to: string): string | undefined;
+  branches?: Accessor<Branch[]>;
 }
 
 export interface RouterUtils {
@@ -159,6 +160,7 @@ export interface RouterContext {
   renderPath(path: string): string;
   parsePath(str: string): string;
   beforeLeave: BeforeLeaveLifecycle;
+  preloadFactory: () => (path: string) => void;
 }
 
 export interface BeforeLeaveEventArgs {

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,7 @@ export interface RouterOutput {
   matches: OutputMatch[][];
 }
 
-export interface RouterContext {
+export interface RouterContext extends LinkPreloadOpts {
   base: RouteContext;
   out?: RouterOutput;
   location: Location;
@@ -181,4 +181,9 @@ export interface BeforeLeaveListener {
 export interface BeforeLeaveLifecycle {
   subscribe(listener: BeforeLeaveListener): () => void;
   confirm(to: string | number, options?: Partial<NavigateOptions>): boolean;
+}
+
+export interface LinkPreloadOpts {
+  preload?: false | "intent";
+  preloadDelay?: number;
 }


### PR DESCRIPTION
This PR adds `preload`  (similar to `remix`) and `preloadDelay` (similar to `tanstack-router`) options to the `Router` and `Link` components.

I'm slowly making my way over from the world of React, so the particular implementation I chose might not be ideal (more on this in comments). I tried to minimize the amount of change, and it seemed a little awkward to get access to the relevant route data and asset preload functions in the right spots given how things are currently organized.

- [x] No breaking changes
- [ ] No tests added - figured I'd wait to get feedback on whether this PR might be accepted or not before spending time here
- [ ] Ditto re docs - can update the readme if this is something that might get merged

**Usage**

```tsx
// Set global defaults via Router
<Router preload="intent" preloadDelay={500} />

// Override global default on a per Link basis
<Link preload="intent" preloadDelay={500} />
```

If the target route has a data function AND/OR if it has a lazy loaded component, the data func and lazy assets will be prefetched.