### PR TITLE
💥 !Define `searchParamIntegration`! 💥

### DIFF
--- a/src/integration.ts
+++ b/src/integration.ts
@@ -178,15 +178,15 @@ export function hashIntegration() {
       go: delta => window.history.go(delta),
       renderPath: path => `#${path}`,
       parsePath: str => {
+        // Get everything after the `#` (by dropping everything before the `#`)
         const to = str.replace(/^.*?#/, "");
-        // Hash-only hrefs like `#foo` from plain anchors will come in as `/#foo` whereas a link to
-        // `/foo` will be `/#/foo`. Check if the to starts with a `/` and if not append it as a hash
-        // to the current path so we can handle these in-page anchors correctly.
         if (!to.startsWith("/")) {
+          // We got an in-page heading link.
+          // Append it to the current path to maintain correct browser behavior.
           const [, path = "/"] = window.location.hash.split("#", 2);
           return `${path}#${to}`;
         }
-        return to;
+        return to; // Normal Solidjs <A> link
       }
     }
   );

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -32,6 +32,11 @@ function scrollToHash(hash: string, fallbackTop?: boolean) {
   }
 }
 
+/**
+ * Store location history in a local variable.
+ *
+ * (other router integrations "store" state as urls in browser history)
+ */
 export function createMemoryHistory() {
   const entries = ["/"];
   let index = 0;
@@ -75,10 +80,16 @@ export function createMemoryHistory() {
   };
 }
 
+type NotifyLocationChange = (value?: string | LocationChange) => void;
+
+type CreateLocationChangeNotifier = (
+  notify: NotifyLocationChange
+) => /* LocationChangeNotifier: */ () => void;
+
 export function createIntegration(
   get: () => string | LocationChange,
   set: (next: LocationChange) => void,
-  init?: (notify: (value?: string | LocationChange) => void) => () => void,
+  init?: CreateLocationChangeNotifier,
   utils?: Partial<RouterUtils>
 ): RouterIntegration {
   let ignore = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,7 @@ export interface RouteContext {
 }
 
 export interface RouterUtils {
+  /** This produces the `href` attribute shown in the browser. */
   renderPath(path: string): string;
   parsePath(str: string): string;
   go(delta: number): void;

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -1,4 +1,28 @@
 import { hashIntegration } from "../src/integration";
+import { searchParamIntegration } from "../src/integration";
+
+describe("query integration should", () => {
+  const widgetUrl = `/add-account?type=dex#/ugh`;
+  const encodedPath = encodeURIComponent(widgetUrl);
+  test.each([
+    ["http://localhost/", "/"], 
+    ["http://localhost//#/practice", "/"],
+    ["http://localhost/base/#/practice", "/"],
+    ["http://localhost/#/practice#some-id", "/"],
+    ["file:///C:/Users/Foo/index.html#/test", "/"],
+    [`http://localhost/?carniatomon=${encodedPath}`, widgetUrl], 
+    [`http://localhost/?carniatomon=${encodedPath}#/practice`, widgetUrl],
+    [`http://localhost/base/?carniatomon=${encodedPath}#/practice`, widgetUrl],
+    [`http://localhost/?carniatomon=${encodedPath}#/practice#some-id`, widgetUrl],
+    [`file:///C:/Users/Foo/index.html?carniatomon=${encodedPath}#/test`, widgetUrl]
+  ])(`parse paths (case '%s' as '%s')`, (urlString, expected) => {
+    const parsed = searchParamIntegration(
+      'carniatomon'
+    ).utils!.parsePath!(urlString);
+    expect(parsed).toBe(expected);
+  });
+});
+
 
 describe("Hash integration should", () => {
   test.each([


### PR DESCRIPTION
Context: I am building a SolidStart app which will be embedded into other non-Solid-based apps by simply injecting the html+scripts of the SolidStart app at runtime. Once an initial URL is constructed for the SolidStart app, a component similar to [this](https://github.com/justinfagnani/html-include-element/pull/24) is used to inject the scripts + html. The html+scripts come from my SSR'd SolidStart app.

Context2: To make this SolidStart "widget" or "micro-frontend" truly isomorphic, it needs to add some state into the url. (Cookies could be another option). This of course allows the server to SSR the right page.

This PR creates a new way for Solid apps to handle routing, where the pathname and search params for a solid app are encoded into a single search param. This allows Solid apps to be embedded into larger apps without adversely affecting their url.

Host url: `/hPath1/hPath2?hParam1=hParam1Value#hHash`
Solid app's url: `const solidUrl = '/sPath1/sPath2?sParam1=sParam1Value#sHash'`

Host app's url, with Solid app embedded inside it:
1. Set query param: `searchParamIntegration('CARNIATOMON')`
2. Encode it: `/hPath1/hPath2?hParam1=hParam1Value&CARNIATOMON=${encodeURIComponent(solidUrl)}#hHash`
3. Fully encoded: `/hPath1/hPath2?hParam1=hParam1Value&CARNIATOMON=%2FsPath1%2FsPath2%3FsParam1%3DsParam1Value%23sHash#hHash`