### PR TITLE
Allow for readonly arrays to be passed as `MatchFilter`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,7 @@ export type RouteDefinition<S extends string | string[] = any> = {
     }
 );
 
-export type MatchFilter = string[] | RegExp | ((s: string) => boolean);
+export type MatchFilter = readonly string[] | RegExp | ((s: string) => boolean);
 
 export type PathParams<P extends string | readonly string[]> =
   P extends `${infer Head}/${infer Tail}`


### PR DESCRIPTION
Solves following issue:

![image](https://github.com/solidjs/solid-router/assets/24491503/38235e55-75c2-4bbc-a4f9-c9784b3bc80a)
