### PR TITLE
Extend useBeforeLeave for browser initiated events (eg back/forward)

### DIFF
--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,4 +1,5 @@
-import { BeforeLeaveLifecycle, BeforeLeaveListener, NavigateOptions } from "./types";
+import { isServer } from "solid-js/web";
+import { BeforeLeaveLifecycle, BeforeLeaveListener, LocationChange, NavigateOptions } from "./types";
 
 export function createBeforeLeave(): BeforeLeaveLifecycle {
   let listeners = new Set<BeforeLeaveListener>();
@@ -32,5 +33,47 @@ export function createBeforeLeave(): BeforeLeaveLifecycle {
   return {
     subscribe,
     confirm
+  };
+}
+
+// The following supports browser initiated blocking (eg back/forward)
+
+let depth: number;
+export function saveCurrentDepth() {
+  if (!window.history.state || window.history.state._depth == null) {
+    window.history.replaceState({ ...window.history.state, _depth: window.history.length - 1 }, "");
+  }
+  depth = window.history.state._depth;
+}
+if (!isServer) {
+  saveCurrentDepth();
+}
+
+export function keepDepth(state: any) {
+  return {
+    ...state,
+    _depth: window.history.state && window.history.state._depth
+  };
+}
+
+export function notifyIfNotBlocked(
+  notify: (value?: string | LocationChange) => void,
+  block: (delta: number | null) => boolean
+) {
+  let ignore = false;
+  return () => {
+    const prevDepth = depth;
+    saveCurrentDepth();
+    const delta = prevDepth == null ? null : depth - prevDepth;
+    if (ignore) {
+      ignore = false;
+      return;
+    }
+    if (delta && block(delta)) {
+      ignore = true;
+      window.history.go(-delta);
+    } else {
+      notify();
+    }
   };
 }

--- a/src/routers/Router.ts
+++ b/src/routers/Router.ts
@@ -4,28 +4,42 @@ import { StaticRouter } from "./StaticRouter";
 import { setupNativeEvents } from "../data/events";
 import type { BaseRouterProps } from "./components";
 import type { JSX } from "solid-js";
+import { createBeforeLeave, keepDepth, notifyIfNotBlocked, saveCurrentDepth } from "../lifecycle";
 
 export type RouterProps = BaseRouterProps & { url?: string, actionBase?: string, explicitLinks?: boolean, preload?: boolean };
 
 export function Router(props: RouterProps): JSX.Element {
   if (isServer) return StaticRouter(props);
+  const getSource = () => ({
+    value: window.location.pathname + window.location.search + window.location.hash,
+    state: window.history.state
+  });
+  const beforeLeave = createBeforeLeave();
   return createRouter({
-    get: () => ({
-      value: window.location.pathname + window.location.search + window.location.hash,
-      state: history.state
-    }),
+    get: getSource,
     set({ value, replace, scroll, state }) {
       if (replace) {
-        window.history.replaceState(state, "", value);
+        window.history.replaceState(keepDepth(state), "", value);
       } else {
         window.history.pushState(state, "", value);
       }
       scrollToHash(window.location.hash.slice(1), scroll);
+      saveCurrentDepth();
     },
-    init: notify => bindEvent(window, "popstate", () => notify()),
+    init: notify => bindEvent(window, "popstate",
+        notifyIfNotBlocked(notify, delta => {
+          if (delta && delta < 0) {
+            return !beforeLeave.confirm(delta);
+          } else {
+            const s = getSource();
+            return !beforeLeave.confirm(s.value, { state: s.state });
+          }
+        })
+      ),
     create: setupNativeEvents(props.preload, props.explicitLinks, props.actionBase),
     utils: {
-      go: delta => window.history.go(delta)
+      go: delta => window.history.go(delta),
+      beforeLeave
     }
   })(props);
 }

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -345,7 +345,7 @@ export function createRouterContext(
         if (!to) {
           // A delta of 0 means stay at the current location, so it is ignored
         } else if (utils.go) {
-          beforeLeave.confirm(to, options) && utils.go(to);
+          utils.go(to);
         } else {
           console.warn("Router integration does not support relative routing");
         }


### PR DESCRIPTION
This PR extends `useBeforeLeave` blocking to include router initiated navigations such as back/forward.

See issue https://github.com/solidjs/solid-router/issues/277

We've been using this approach in production for over year now - albeit with the `0.8` router generation and hash integration.  Today I rebased this onto `0.10.1` and did some basic testing.

One aspect that might be contentious is using `_depth` on history state to detect navigation type.

Even if not merged, hopefully this PR offers some guidance for others needing this feature.