### PR TITLE
Add function for cache invalidation

### DIFF
--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -176,6 +176,8 @@ cache.set = (key: string, value: any) => {
   } else cache.set(key, (cached = [now, value, , new Set(version! ? [version] : [])]));
 };
 
+cache.clear = () => getCache().clear();
+
 function matchKey(key: string, keys: string[]) {
   for (let k of keys) {
     if (key.startsWith(k)) return true;


### PR DESCRIPTION
Hi, I started migrating an app from solidjs router 0.9.x and 0.10.x.  The new caching and preload features are nice, but I'm having some trouble with testing.
In my test setup I intercept API requests and inject different stubs for different tests. Since the tests run fast, the new solid router cache function does not invalidate the cache from one test to the next, causing some tests to get API responses made for previous tests when making the same requests.

I looked at the source code of cache and there seems to be no way to invalidate the entire cache. I saw that there is a `cache.set` function there but it seems it can't be used for invalidating individual caches.
I really don't want to change components' code to fetch without caching for tests, so it would be interesting to have some sort of `cache.clear` to invalidate the entire cache for testing purposes.

I just created this as a pull request because it is not really an issue and the change proposal is very small, but there might be better ways to do this invalidation.