### PR TITLE
Fix #337 - BeforeLeaveEventArgs.retry with base

### DIFF
--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -23,7 +23,7 @@ export function createBeforeLeave(): BeforeLeaveLifecycle {
         from: l.location,
         retry: (force?: boolean) => {
           force && (ignore = true);
-          l.navigate(to as string, options);
+          l.navigate(to as string, {...options, resolve: false});
         }
       });
     return !e.defaultPrevented;


### PR DESCRIPTION
This change stops `retry` from resolving the path twice - which was duplicating the base path.