### PR TITLE
feat: expose params on event for use in middlware

### DIFF
--- a/src/routers/components.tsx
+++ b/src/routers/components.tsx
@@ -57,6 +57,15 @@ function Routes(props: { routerState: RouterContext; branches: Branch[] }) {
     getRouteMatches(props.branches, props.routerState.location.pathname)
   );
 
+  const params = createMemoObject(() => {
+    const m = matches();
+    const params: Params = {};
+    for (let i = 0; i < m.length; i++) {
+      Object.assign(params, m[i].params);
+    }
+    return params;
+  });
+
   if (isServer) {
     const e = getRequestEvent();
     e &&
@@ -69,15 +78,10 @@ function Routes(props: { routerState: RouterContext; branches: Branch[] }) {
           metadata: route.metadata
         }))
       );
+
+    e && (e.context.params = params);
   }
-  const params = createMemoObject(() => {
-    const m = matches();
-    const params: Params = {};
-    for (let i = 0; i < m.length; i++) {
-      Object.assign(params, m[i].params);
-    }
-    return params;
-  });
+
   const disposers: (() => void)[] = [];
   let root: RouteContext | undefined;
 
@@ -134,7 +138,7 @@ const createOutlet = (child: () => RouteContext | undefined) => {
   );
 };
 
-export type RouteProps<S extends string, T=unknown> = {
+export type RouteProps<S extends string, T = unknown> = {
   path?: S | S[];
   children?: JSX.Element;
   load?: RouteLoadFunc<T>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ declare module "solid-js/web" {
     routerCache?: Map<any, any>;
     initialSubmission?: Submission<any, any>;
     serverOnly?: boolean;
+    context: any
   }
 }
 
@@ -81,14 +82,14 @@ export type MatchFilter = readonly string[] | RegExp | ((s: string) => boolean);
 
 export type PathParams<P extends string | readonly string[]> =
   P extends `${infer Head}/${infer Tail}`
-    ? [...PathParams<Head>, ...PathParams<Tail>]
-    : P extends `:${infer S}?`
-    ? [S]
-    : P extends `:${infer S}`
-    ? [S]
-    : P extends `*${infer S}`
-    ? [S]
-    : [];
+  ? [...PathParams<Head>, ...PathParams<Tail>]
+  : P extends `:${infer S}?`
+  ? [S]
+  : P extends `:${infer S}`
+  ? [S]
+  : P extends `*${infer S}`
+  ? [S]
+  : [];
 
 export type MatchFilters<P extends string | readonly string[] = any> = P extends string
   ? { [K in PathParams<P>[number]]?: MatchFilter }


### PR DESCRIPTION
This would allow you access to url params in the middeware.  Saw someone ask for it and figured this out.

```typescript
export default createMiddleware({
    onBeforeResponse: [
        event => {
            console.log(event.context.params?.id);
        },
    ]
});
```