### PR TITLE
Partial fix for #344

### DIFF
--- a/src/routers/components.tsx
+++ b/src/routers/components.tsx
@@ -143,7 +143,7 @@ export type RouteProps<S extends string, T=unknown> = {
   metadata?: Record<string, any>;
 };
 
-export const Route = <S extends string>(props: RouteProps<S>) => {
+export const Route = <S extends string, T = unknown>(props: RouteProps<S, T>) => {
   const childRoutes = children(() => props.children);
   return mergeProps(props, {
     get children() {


### PR DESCRIPTION
I believe this is a partial fix to #344 . Now a `Route` can have props of type `RouteProps<S, T>` rather than just `RouteProps<S, undefined>`