### PR TITLE
Form action set as insecure by google chrome.

### DIFF
--- a/src/data/action.ts
+++ b/src/data/action.ts
@@ -97,8 +97,8 @@ export function action<T extends Array<any>, U = void>(
 
   const url: string =
     (fn as any).url ||
-    (name && `https://action:${name}`) ||
-    (!isServer ? `https://action:${hashString(fn.toString())}` : "");
+    (name && `https://action/${name}`) ||
+    (!isServer ? `https://action/${hashString(fn.toString())}` : "");
   return toAction(mutate, url);
 }
 
@@ -118,7 +118,7 @@ function toAction<T extends Array<any>, U>(fn: Function, url: string): Action<T,
     uri.searchParams.set("args", hashKey(args));
     return toAction<B, U>(
       newFn as any,
-      (uri.protocol === "https://action:" ? uri.protocol : "") + uri.pathname + uri.search
+      (uri.protocol === "https://action/" ? uri.protocol : "") + uri.pathname + uri.search
     );
   };
   (fn as any).url = url;

--- a/src/data/action.ts
+++ b/src/data/action.ts
@@ -97,8 +97,8 @@ export function action<T extends Array<any>, U = void>(
 
   const url: string =
     (fn as any).url ||
-    (name && `action:${name}`) ||
-    (!isServer ? `action:${hashString(fn.toString())}` : "");
+    (name && `https://action:${name}`) ||
+    (!isServer ? `https://action:${hashString(fn.toString())}` : "");
   return toAction(mutate, url);
 }
 
@@ -118,7 +118,7 @@ function toAction<T extends Array<any>, U>(fn: Function, url: string): Action<T,
     uri.searchParams.set("args", hashKey(args));
     return toAction<B, U>(
       newFn as any,
-      (uri.protocol === "action:" ? uri.protocol : "") + uri.pathname + uri.search
+      (uri.protocol === "https://action:" ? uri.protocol : "") + uri.pathname + uri.search
     );
   };
   (fn as any).url = url;

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -101,7 +101,7 @@ export function setupNativeEvents(preload = true, explicitLinks = false, actionB
           ? (evt.submitter as HTMLButtonElement | HTMLInputElement).formAction
           : (evt.target as any).action;
       if (!actionRef) return;
-      if (!actionRef.startsWith("https://action:")) {
+      if (!actionRef.startsWith("https://action/")) {
         const url = new URL(actionRef);
         actionRef = router.parsePath(url.pathname + url.search);
         if (!actionRef.startsWith(actionBase)) return;

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -31,7 +31,7 @@ export function setupNativeEvents(preload = true, explicitLinks = false, actionB
         | SVGAElement
         | undefined;
 
-      if (!a || (explicitLinks && !a.getAttribute("link")) ) return;
+      if (!a || (explicitLinks && !a.getAttribute("link"))) return;
 
       const svg = isSvg(a);
       const href = svg ? a.href.baseVal : a.href;
@@ -101,7 +101,7 @@ export function setupNativeEvents(preload = true, explicitLinks = false, actionB
           ? (evt.submitter as HTMLButtonElement | HTMLInputElement).formAction
           : (evt.target as any).action;
       if (!actionRef) return;
-      if (!actionRef.startsWith("action:")) {
+      if (!actionRef.startsWith("https://action:")) {
         const url = new URL(actionRef);
         actionRef = router.parsePath(url.pathname + url.search);
         if (!actionRef.startsWith(actionBase)) return;


### PR DESCRIPTION
Fixes issue #349

When accessing a website with https, the forms action="" that are not https:// are set as insecure by Google Chrome [Google Chrome Docs](https://blog.chromium.org/2020/08/protecting-google-chrome-users-from.html).

The new form action on @solidjs/router renders the markup like this:

`<form method="post" action="action:signUpForm">...</form>`

This PR changes the action to:

`<form method="post" action="https://action/signUpForm">...</form>`

Preventing Google Chrome from seeing the action as unsafe.