### PR TITLE
encode path components

### DIFF
--- a/src/routing.ts
+++ b/src/routing.ts
@@ -180,7 +180,13 @@ export function createBranches(
   for (let i = 0, len = routeDefs.length; i < len; i++) {
     const def = routeDefs[i];
     if (def && typeof def === "object") {
-      if (!def.hasOwnProperty("path")) def.path = "";
+      if (!def.hasOwnProperty("path")) {
+        def.path = "";
+      } else {
+        def.path = def.path.split("/").map((s: string) => {
+          return (s.startsWith(':') || s.startsWith('*')) ? s : encodeURIComponent(s)
+        }).join("/");
+      }
       const routes = createRoutes(def, base);
       for (const route of routes) {
         stack.push(route);

--- a/test/route.spec.ts
+++ b/test/route.spec.ts
@@ -526,4 +526,34 @@ describe("createBranches should", () => {
     expect(scores[2]).toBeGreaterThan(scores[3]);
     expect(scores[3]).toBeGreaterThan(scores[4]);
   });
+
+  test(`encode path components`, () => {
+    const branches = createBranches({
+      path: "root",
+      children: [
+        {
+          path: "foo/ほげ/ふが/bar"
+        }
+      ]
+    });
+
+    const branchPaths = branches.map(b => b.routes[b.routes.length - 1].pattern);
+
+    expect(branchPaths).toEqual(["/root/foo/%E3%81%BB%E3%81%92/%E3%81%B5%E3%81%8C/bar"]);
+  });
+
+  test(`not encode parameters or named splats`, () => {
+    const branches = createBranches({
+      path: "root",
+      children: [
+        {
+          path: "ほげ/:ふが/*ぴよ"
+        }
+      ]
+    });
+
+    const branchPaths = branches.map(b => b.routes[b.routes.length - 1].pattern);
+
+    expect(branchPaths).toEqual(["/root/%E3%81%BB%E3%81%92/:ふが/*ぴよ"]);
+  });
 });


### PR DESCRIPTION
(fixes the same thing as https://github.com/solidjs/solid-start/pull/1241 from the router end if this is preferred)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
- Create a file or directory within your routes containing characters that browsers encode, for example src/routes/漢字.tsx
- Browse /漢字
- Not found

Need to rename the file to %25E6%25BC%25A2%25E5%25AD%2597.tsx. This isn't documented anywhere and shouldn't be necessary. File and directory names like this are too unwieldy to use.

## What is the new behavior?
- Create a src/routes/漢字.tsx
- Browse /漢字
- Page loads as expected