### PR TITLE
fix memory router no native events

### DIFF
--- a/src/routers/MemoryRouter.ts
+++ b/src/routers/MemoryRouter.ts
@@ -1,4 +1,5 @@
 import { createRouter, scrollToHash } from "./createRouter.js";
+import { setupNativeEvents } from "../data/events.js";
 import type { LocationChange } from "../types.js";
 import type { BaseRouterProps } from "./components.jsx";
 import type { JSX } from "solid-js";
@@ -62,6 +63,7 @@ export function MemoryRouter(props: MemoryRouterProps): JSX.Element {
     get: memoryHistory.get,
     set: memoryHistory.set,
     init: memoryHistory.listen,
+    create: setupNativeEvents(),
     utils: {
       go: memoryHistory.go
     }


### PR DESCRIPTION
Without `setupNativeEvents` function MemoryRouter does not work with <A></A> component, because it is basically just a link that navigates to some page. As stated in the [docs](https://github.com/solidjs/solid-router?tab=readme-ov-file#memory-mode-router) memory router can be used for testing purpose. I guess <A></A> component should not break then. I know that `useNavigate` still works, but I think links should work too.

Maybe there wasn't `setupNativeEvents` on purpose because there is no types in component declaration for arguments of this function, so It's not just was forgotten, so feel free to reject this PR if that's like that.