### PR TITLE
Run load functions with owner & context of `Router` component.

### DIFF
--- a/.changeset/spicy-hornets-visit.md
+++ b/.changeset/spicy-hornets-visit.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Run load functions with owner & context of `Router` component.

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,4 +1,4 @@
-import { JSX, Accessor } from "solid-js";
+import { JSX, Accessor, getOwner, runWithOwner } from "solid-js";
 import {
   createComponent,
   createContext,
@@ -330,6 +330,8 @@ export function createRouterContext(
     });
   });
 
+  const owner = getOwner();
+
   return {
     base: baseRoute,
     location,
@@ -440,20 +442,23 @@ export function createRouterContext(
       route.component &&
         (route.component as MaybePreloadableComponent).preload &&
         (route.component as MaybePreloadableComponent).preload!();
+      const { load } = route;
       preloadData &&
-        route.load &&
-        route.load({
-          params,
-          location: {
-            pathname: url.pathname,
-            search: url.search,
-            hash: url.hash,
-            query: extractSearchParams(url),
-            state: null,
-            key: ""
-          },
-          intent: "preload"
-        });
+        load &&
+        runWithOwner(owner, () =>
+          load({
+            params,
+            location: {
+              pathname: url.pathname,
+              search: url.search,
+              hash: url.hash,
+              query: extractSearchParams(url),
+              state: null,
+              key: ""
+            },
+            intent: "preload"
+          })
+        );
     }
     intent = prevIntent;
   }


### PR DESCRIPTION
It can be useful (and sometimes necessary) to access contexts declared above the `<Router>` inside loaders.
In my case, we are preloading data using tRPC, which relies on `useQueryClient` to pull the tanstack query client out of context. This context provider is registered above the `<Router>`, ie. available at the top-level where loaders execute, but is currently inaccessible as load functions are not run in the context of any owner.
To allow this to work, I've simply grabbed the router's owner and wrapped the loader invocation with `runWithOwner`.
While this does work, I wouldn't be surprised if also wrapping the loader invocation with `createRoot` is necessary to account for some hooks that may read from context and create effects.