### PR TITLE
Fix types for cache functions with all optional arguments

### DIFF
--- a/.changeset/nervous-rockets-turn.md
+++ b/.changeset/nervous-rockets-turn.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Fix types for cache functions with all optional arguments

--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -55,7 +55,9 @@ export function cacheKeyOp(key: string | string[] | void, fn: (cacheEntry: Cache
 export type CachedFunction<T extends (...args: any) => any> = T extends (
   ...args: infer A
 ) => infer R
-  ? ([] extends A ? (...args: never[]) => R : T) & {
+  ? ([] extends { [K in keyof A]-?: A[K] } // A tuple full of optional values is equivalent to an empty tuple
+      ? (...args: never[]) => R
+      : T) & {
       keyFor: (...args: A) => string;
       key: string;
     }


### PR DESCRIPTION
`cache` functions with all optional arguments are currently casted to `(...args: never[]) => T` as `[]` apparently extends tuples with all optional values. This fixes that by doing the `[] extends` comparison against the argument list with optionality removed. This should be fine since the only important part of that check is whether there are >0 arguments, we don't really care about the types.