### PR TITLE
Make MemoryRouter set navigate and scroll

### DIFF
--- a/src/routers/MemoryRouter.ts
+++ b/src/routers/MemoryRouter.ts
@@ -33,9 +33,15 @@ export function createMemoryHistory() {
         entries.splice(index + 1, entries.length - index, value);
         index++;
       }
-      if (scroll) {
-        scrollToHash(value.split("#")[1] || "", true);
-      }
+
+      listeners.forEach(listener => listener(value));
+
+      setTimeout(() => {
+        if (scroll) {
+          scrollToHash(value.split("#")[1] || "", true);
+        }
+      }, 1000);
+      
     },
     back: () => {
       go(-1);


### PR DESCRIPTION
I don't know if there is a better way to do this, but
- triggering the listeners will enable the navigation
- setTimeout(()=>{}, 0) allow for scroll after navigation.

Closes #393 