### PR TITLE
fix(#396) - useLocation().state does not get updated on history back on same URL

### DIFF
--- a/src/routers/createRouter.ts
+++ b/src/routers/createRouter.ts
@@ -32,7 +32,7 @@ export function createRouter(config: {
   let ignore = false;
   const wrap = (value: string | LocationChange) => (typeof value === "string" ? { value } : value);
   const signal = intercept<LocationChange>(
-    createSignal(wrap(config.get()), { equals: (a, b) => a.value === b.value }),
+    createSignal(wrap(config.get()), { equals: (a, b) => a.value === b.value && JSON.stringify(b.state) === JSON.stringify(a.state) }),
     undefined,
     next => {
       !ignore && config.set(next);


### PR DESCRIPTION
This change should ensure `useLocation().state` reflects `history.state` on history back and reactively updates.

NOTE: I have not tested this change!
I don't know how this behaves with solid-routers state: `{_depth: number}` special property.