### PR TITLE
don't submit form when submitevent get defaultPrevented

### DIFF
--- a/.changeset/poor-pants-vanish.md
+++ b/.changeset/poor-pants-vanish.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+don't submit form when submit event is defaultPrevented

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -97,6 +97,7 @@ export function setupNativeEvents(preload = true, explicitLinks = false, actionB
     }
 
     function handleFormSubmit(evt: SubmitEvent) {
+      if (evt.defaultPrevented) return;
       let actionRef =
         evt.submitter && evt.submitter.hasAttribute("formaction")
           ? evt.submitter.getAttribute("formaction")


### PR DESCRIPTION
Fix #400 

## Objective
The pull request aim to not run action when someone call preventDefault on the submitevent.

## Remarks
1. I didn't run prettier and there is a ts error when I build the project that was already there.
2. I'm not sure where to abort the handleFormSubmit function I choose to abort as soon as possible but maybe there are better place performance wise