### PR TITLE
feat(action): Error message for when calling raw action

### DIFF
--- a/.changeset/bright-rocks-share.md
+++ b/.changeset/bright-rocks-share.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Add an error message to when calling an action without first wrapping it in `useAction`

--- a/src/data/action.ts
+++ b/src/data/action.ts
@@ -60,6 +60,40 @@ export function action<T extends Array<any>, U = void>(
   name?: string
 ): Action<T, U> {
   function mutate(this: { r: RouterContext; f?: HTMLFormElement }, ...variables: T) {
+    if (typeof this !== 'object' || !Object.hasOwn(this, 'r')) {
+      throw new Error(`Seems like you are directly calling a function wrapped in "action". To properly use an action, you will need to first call "useAction". 
+
+So, if you have code like this:
+
+1    const myFunc = action(...);
+2  
+3 /  function MyComponent() {
+4 |    return <button 
+5 |      onClick={() => myFunc(...)}
+  |____________________^ This is where the error is going to happen
+6      >
+7        Click me!
+8      </button>
+9    }
+
+You will need to change it to something like:
+
+1    const myAction = action(...);
+2    
+3    function MyComponent() {
+4      const callMyAction = useAction(myAction);
+5    
+6      return <button 
+7        onClick={() => callMyAction(...)}
+8      >
+9        Click me!
+10     </button>
+11   }
+
+This is the case because the action will need to tune itself to the surrounding context for the Router so that it can
+keep track of all the submissions. See https://docs.solidjs.com/solid-router/concepts/actions#creating-actions for more information on how to use actions.
+`)
+    }
     const router = this.r;
     const form = this.f;
     const p = (


### PR DESCRIPTION
A few times I've called the actions and taking a bit to figure out
this was the case, so I decided to add an error message that might
be helpful to others in this. The error message currently looks like:

```
Seems like you are directly calling a function wrapped in "action". To properly use an action, you will need to first call "useAction". 

So, if you have code like this:

1    const myFunc = action(...);
2  
3 /  function MyComponent() {
4 |    return <button 
5 |      onClick={() => myFunc(...)}
  |____________________^ This is where the error is going to happen
6      >
7        Click me!
8      </button>
9    }

You will need to change it to something like:

1    const myAction = action(...);
2    
3    function MyComponent() {
4      const callMyAction = useAction(myAction);
5    
6      return <button 
7        onClick={() => callMyAction(...)}
8      >
9        Click me!
10     </button>
11   }

This is the case because the action will need to tune itself to the surrounding context for the Router so that it can
keep track of all the submissions. See https://docs.solidjs.com/solid-router/concepts/actions#creating-actions for more information on how to use actions.
```

Tried writing it to be clear and show examples so that the person can understand
even if they don't end up look into the docs for this.

<details>
  <summary>Examples of how the error looks like on different browsers:</summary>

  <table>
      <tr>
          <th>Firefox</th>
          <th>Chrome</th>
      </ŧr>
      <tr>
          <td>
              <img src="https://github.com/solidjs/solid-router/assets/88866334/cc059e5e-af0d-4b57-82b1-08327d8db27f">
          </td>
          <td>
              <img src="https://github.com/solidjs/solid-router/assets/88866334/c3060ac7-ce6d-4f07-a6ad-fb0ac13949be">
          </td>
      </tr>
  </table>
</details>

Let me know if the condition it checks for makes sense in this situation.

Thanks!
