### PR TITLE
fix: state updates detection on history back/forward

### DIFF
--- a/.changeset/lucky-dingos-happen.md
+++ b/.changeset/lucky-dingos-happen.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Fix state updates detection on history back/forward

--- a/src/routers/createRouter.ts
+++ b/src/routers/createRouter.ts
@@ -1,7 +1,6 @@
 import { Signal, createSignal, onCleanup } from "solid-js";
 import type { LocationChange, RouterContext, RouterUtils } from "../types.ts";
 import { createRouterComponent } from "./components.jsx";
-import { equalObjects } from "../utils.js";
 
 function intercept<T>(
   [value, setValue]: [() => T, (v: T) => void],
@@ -34,7 +33,7 @@ export function createRouter(config: {
   const wrap = (value: string | LocationChange) => (typeof value === "string" ? { value } : value);
   const signal = intercept<LocationChange>(
     createSignal(wrap(config.get()), {
-      equals: (a, b) => a.value === b.value && equalObjects(a.state, b.state)
+      equals: (a, b) => a.value === b.value && a.state === b.state
     }),
     undefined,
     next => {

--- a/src/routers/createRouter.ts
+++ b/src/routers/createRouter.ts
@@ -1,6 +1,7 @@
 import { Signal, createSignal, onCleanup } from "solid-js";
 import type { LocationChange, RouterContext, RouterUtils } from "../types.ts";
 import { createRouterComponent } from "./components.jsx";
+import { equalObjects } from "../utils.js";
 
 function intercept<T>(
   [value, setValue]: [() => T, (v: T) => void],
@@ -32,7 +33,9 @@ export function createRouter(config: {
   let ignore = false;
   const wrap = (value: string | LocationChange) => (typeof value === "string" ? { value } : value);
   const signal = intercept<LocationChange>(
-    createSignal(wrap(config.get()), { equals: false }),
+    createSignal(wrap(config.get()), {
+      equals: (a, b) => a.value === b.value && equalObjects(a.state, b.state)
+    }),
     undefined,
     next => {
       !ignore && config.set(next);

--- a/src/routers/createRouter.ts
+++ b/src/routers/createRouter.ts
@@ -32,7 +32,7 @@ export function createRouter(config: {
   let ignore = false;
   const wrap = (value: string | LocationChange) => (typeof value === "string" ? { value } : value);
   const signal = intercept<LocationChange>(
-    createSignal(wrap(config.get()), { equals: (a, b) => a.value === b.value }),
+    createSignal(wrap(config.get()), { equals: false }),
     undefined,
     next => {
       !ignore && config.set(next);

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -7,6 +7,7 @@ import {
   createSignal,
   on,
   onCleanup,
+  onMount,
   untrack,
   useContext,
   startTransition,
@@ -325,6 +326,10 @@ export function createRouterContext(
       return resolvePath(basePath, to);
     }
   };
+
+  const handlePopState = () => setState(window.history.state);
+  onMount(() => window.addEventListener("popstate", handlePopState));
+  onCleanup(() => window.removeEventListener("popstate", handlePopState));
 
   createRenderEffect(() => {
     const { value, state } = source();

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -326,12 +326,6 @@ export function createRouterContext(
     }
   };
 
-  if (!isServer) {
-    const syncState = () => setState(window.history.state);
-    window.addEventListener("popstate", syncState);
-    onCleanup(() => window.removeEventListener("popstate", syncState));
-  }
-
   createRenderEffect(() => {
     const { value, state } = source();
     // Untrack this whole block so `start` doesn't cause Solid's Listener to be preserved
@@ -343,6 +337,13 @@ export function createRouterContext(
           setState(state);
           resetErrorBoundaries();
           submissions[1]([]);
+        }).then(() => {
+          intent = undefined;
+        });
+      } else {
+        start(() => {
+          intent = "native";
+          setState(state);
         }).then(() => {
           intent = undefined;
         });

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -44,7 +44,8 @@ import {
   joinPaths,
   scoreRoute,
   mergeSearchString,
-  expandOptionals
+  expandOptionals,
+  equalObjects
 } from "./utils.js";
 
 const MAX_REDIRECTS = 100;
@@ -327,23 +328,16 @@ export function createRouterContext(
   };
 
   createRenderEffect(() => {
-    const { value, state } = source();
+    const { value, state: nextState } = source();
     // Untrack this whole block so `start` doesn't cause Solid's Listener to be preserved
     untrack(() => {
-      if (value !== reference()) {
+      if (value !== reference() || !equalObjects(nextState, state())) {
         start(() => {
           intent = "native";
           setReference(value);
-          setState(state);
+          setState(nextState);
           resetErrorBoundaries();
           submissions[1]([]);
-        }).then(() => {
-          intent = undefined;
-        });
-      } else {
-        start(() => {
-          intent = "native";
-          setState(state);
         }).then(() => {
           intent = undefined;
         });

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -7,7 +7,6 @@ import {
   createSignal,
   on,
   onCleanup,
-  onMount,
   untrack,
   useContext,
   startTransition,
@@ -327,9 +326,11 @@ export function createRouterContext(
     }
   };
 
-  const handlePopState = () => setState(window.history.state);
-  onMount(() => window.addEventListener("popstate", handlePopState));
-  onCleanup(() => window.removeEventListener("popstate", handlePopState));
+  if (!isServer) {
+    const syncState = () => setState(window.history.state);
+    window.addEventListener("popstate", syncState);
+    onCleanup(() => window.removeEventListener("popstate", syncState));
+  }
 
   createRenderEffect(() => {
     const { value, state } = source();

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -44,8 +44,7 @@ import {
   joinPaths,
   scoreRoute,
   mergeSearchString,
-  expandOptionals,
-  equalObjects
+  expandOptionals
 } from "./utils.js";
 
 const MAX_REDIRECTS = 100;
@@ -328,20 +327,18 @@ export function createRouterContext(
   };
 
   createRenderEffect(() => {
-    const { value, state: nextState } = source();
+    const { value, state } = source();
     // Untrack this whole block so `start` doesn't cause Solid's Listener to be preserved
     untrack(() => {
-      if (value !== reference() || !equalObjects(nextState, state())) {
-        start(() => {
-          intent = "native";
-          setReference(value);
-          setState(nextState);
-          resetErrorBoundaries();
-          submissions[1]([]);
-        }).then(() => {
-          intent = undefined;
-        });
-      }
+      start(() => {
+        intent = "native";
+        if (value !== reference()) setReference(value);
+        setState(state);
+        resetErrorBoundaries();
+        submissions[1]([]);
+      }).then(() => {
+        intent = undefined;
+      });
     });
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -186,34 +186,3 @@ export function expandOptionals(pattern: string): string[] {
     []
   );
 }
-
-// Modified from fast-deep-equal for objects only (MIT)
-// https://github.com/epoberezkin/fast-deep-equal
-export function equalObjects(a: any, b: any) {
-  if (a === b) return true;
-
-  if (a && b && typeof a == "object" && typeof b == "object") {
-    if (a.constructor !== b.constructor) return false;
-    if (a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
-    if (a.toString !== Object.prototype.toString) return a.toString() === b.toString();
-
-    var length, i, keys;
-    keys = Object.keys(a);
-    length = keys.length;
-
-    if (length !== Object.keys(b).length) return false;
-
-    for (i = length; i-- !== 0; ) {
-      if (!Object.prototype.hasOwnProperty.call(b, keys[i])) return false;
-    }
-
-    for (i = length; i-- !== 0; ) {
-      var key = keys[i];
-      if (!equalObjects(a[key], b[key])) return false;
-    }
-
-    return true;
-  }
-
-  return false;
-}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -186,3 +186,34 @@ export function expandOptionals(pattern: string): string[] {
     []
   );
 }
+
+// Modified from fast-deep-equal for objects only (MIT)
+// https://github.com/epoberezkin/fast-deep-equal
+export function equalObjects(a: any, b: any) {
+  if (a === b) return true;
+
+  if (a && b && typeof a == "object" && typeof b == "object") {
+    if (a.constructor !== b.constructor) return false;
+    if (a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
+    if (a.toString !== Object.prototype.toString) return a.toString() === b.toString();
+
+    var length, i, keys;
+    keys = Object.keys(a);
+    length = keys.length;
+
+    if (length !== Object.keys(b).length) return false;
+
+    for (i = length; i-- !== 0; ) {
+      if (!Object.prototype.hasOwnProperty.call(b, keys[i])) return false;
+    }
+
+    for (i = length; i-- !== 0; ) {
+      var key = keys[i];
+      if (!equalObjects(a[key], b[key])) return false;
+    }
+
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
This PR adds an event listener to `popstate` change event to update the router state with the history back/forward events between two routes with the same paths but with different state objects.

Currently the changes are only detected by refreshing the page.

Closes #275 and #396