### PR TITLE
feat: add URL transformation hook

### DIFF
--- a/.changeset/ten-trains-work.md
+++ b/.changeset/ten-trains-work.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Allow rewriting url

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -4,7 +4,7 @@ import type { RouterContext } from "../types.js";
 import { actions } from "./action.js";
 import { mockBase } from "../utils.js";
 
-export function setupNativeEvents(preload = true, explicitLinks = false, actionBase = "/_server") {
+export function setupNativeEvents(preload = true, explicitLinks = false, actionBase = "/_server", transformUrl?: (url: string) => string) {
   return (router: RouterContext) => {
     const basePath = router.base.path();
     const navigateFromRoute = router.navigatorFactory(router.base);
@@ -71,6 +71,9 @@ export function setupNativeEvents(preload = true, explicitLinks = false, actionB
       const res = handleAnchor(evt as MouseEvent);
       if (!res) return;
       const [a, url] = res;
+      if (typeof transformUrl === "function") {
+        url.pathname = transformUrl(url.pathname);
+      }
       if (!preloadTimeout[url.pathname])
         router.preloadRoute(url, a.getAttribute("preload") !== "false");
     }
@@ -79,6 +82,9 @@ export function setupNativeEvents(preload = true, explicitLinks = false, actionB
       const res = handleAnchor(evt as MouseEvent);
       if (!res) return;
       const [a, url] = res;
+      if (typeof transformUrl === "function") {
+        url.pathname = transformUrl(url.pathname);
+      }
       if (preloadTimeout[url.pathname]) return;
       preloadTimeout[url.pathname] = setTimeout(() => {
         router.preloadRoute(url, a.getAttribute("preload") !== "false");
@@ -90,6 +96,9 @@ export function setupNativeEvents(preload = true, explicitLinks = false, actionB
       const res = handleAnchor(evt as MouseEvent);
       if (!res) return;
       const [, url] = res;
+      if (typeof transformUrl === "function") {
+        url.pathname = transformUrl(url.pathname);
+      }
       if (preloadTimeout[url.pathname]) {
         clearTimeout(preloadTimeout[url.pathname]);
         delete preloadTimeout[url.pathname];

--- a/src/routers/Router.ts
+++ b/src/routers/Router.ts
@@ -6,14 +6,17 @@ import type { BaseRouterProps } from "./components.jsx";
 import type { JSX } from "solid-js";
 import { createBeforeLeave, keepDepth, notifyIfNotBlocked, saveCurrentDepth } from "../lifecycle.js";
 
-export type RouterProps = BaseRouterProps & { url?: string, actionBase?: string, explicitLinks?: boolean, preload?: boolean };
+export type RouterProps = BaseRouterProps & { url?: string, actionBase?: string, explicitLinks?: boolean, preload?: boolean, transformUrl?: (url: string) => string };
 
 export function Router(props: RouterProps): JSX.Element {
   if (isServer) return StaticRouter(props);
-  const getSource = () => ({
-    value: window.location.pathname + window.location.search + window.location.hash,
-    state: window.history.state
-  });
+  const getSource = () => {
+    const url = window.location.pathname + window.location.search;
+    return {
+      value: props.transformUrl ? props.transformUrl(url) + window.location.hash : url + window.location.hash,
+      state: window.history.state
+    }
+  };
   const beforeLeave = createBeforeLeave();
   return createRouter({
     get: getSource,

--- a/src/routers/Router.ts
+++ b/src/routers/Router.ts
@@ -39,7 +39,7 @@ export function Router(props: RouterProps): JSX.Element {
           }
         })
       ),
-    create: setupNativeEvents(props.preload, props.explicitLinks, props.actionBase),
+    create: setupNativeEvents(props.preload, props.explicitLinks, props.actionBase, props.transformUrl),
     utils: {
       go: delta => window.history.go(delta),
       beforeLeave

--- a/src/routers/Router.ts
+++ b/src/routers/Router.ts
@@ -6,7 +6,7 @@ import type { BaseRouterProps } from "./components.jsx";
 import type { JSX } from "solid-js";
 import { createBeforeLeave, keepDepth, notifyIfNotBlocked, saveCurrentDepth } from "../lifecycle.js";
 
-export type RouterProps = BaseRouterProps & { url?: string, actionBase?: string, explicitLinks?: boolean, preload?: boolean, transformUrl?: (url: string) => string };
+export type RouterProps = BaseRouterProps & { url?: string, actionBase?: string, explicitLinks?: boolean, preload?: boolean };
 
 export function Router(props: RouterProps): JSX.Element {
   if (isServer) return StaticRouter(props);

--- a/src/routers/StaticRouter.ts
+++ b/src/routers/StaticRouter.ts
@@ -7,12 +7,13 @@ function getPath(url: string) {
   return u.pathname + u.search;
 }
 
-export type StaticRouterProps = BaseRouterProps & { url?: string };
+export type StaticRouterProps = BaseRouterProps & { url?: string, transformUrl?: (url: string) => string };
 
 export function StaticRouter(props: StaticRouterProps): JSX.Element {
   let e;
+  const url = props.url || ((e = getRequestEvent()) && getPath(e.request.url)) || ""
   const obj = {
-    value: props.url || ((e = getRequestEvent()) && getPath(e.request.url)) || ""
+    value: props.transformUrl ? props.transformUrl(url) : url,
   };
   return createRouterComponent({
     signal: [() => obj, next => Object.assign(obj, next)]

--- a/src/routers/StaticRouter.ts
+++ b/src/routers/StaticRouter.ts
@@ -7,7 +7,7 @@ function getPath(url: string) {
   return u.pathname + u.search;
 }
 
-export type StaticRouterProps = BaseRouterProps & { url?: string, transformUrl?: (url: string) => string };
+export type StaticRouterProps = BaseRouterProps & { url?: string };
 
 export function StaticRouter(props: StaticRouterProps): JSX.Element {
   let e;

--- a/src/routers/components.tsx
+++ b/src/routers/components.tsx
@@ -42,6 +42,7 @@ export type BaseRouterProps = {
   rootLoad?: RouteLoadFunc;
   singleFlight?: boolean;
   children?: JSX.Element | RouteDefinition | RouteDefinition[];
+  transformUrl?: (url: string) => string;
 };
 
 export const createRouterComponent = (router: RouterIntegration) => (props: BaseRouterProps) => {
@@ -54,7 +55,8 @@ export const createRouterComponent = (router: RouterIntegration) => (props: Base
   let context: Owner;
   const routerState = createRouterContext(router, branches, () => context, {
     base,
-    singleFlight: props.singleFlight
+    singleFlight: props.singleFlight,
+    transformUrl: props.transformUrl,
   });
   router.create && router.create(routerState);
   return (

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -273,7 +273,7 @@ export function createRouterContext(
   integration: RouterIntegration,
   branches: () => Branch[],
   getContext?: () => any,
-  options: { base?: string; singleFlight?: boolean } = {}
+  options: { base?: string; singleFlight?: boolean, transformUrl?: (url: string) => string } = {}
 ): RouterContext {
   const {
     signal: [source, setSource],
@@ -306,7 +306,13 @@ export function createRouterContext(
   const referrers: LocationChange[] = [];
   const submissions = createSignal<Submission<any, any>[]>(isServer ? initFromFlash() : []);
 
-  const matches = createMemo(() => getRouteMatches(branches(), location.pathname));
+  const matches = createMemo(() => {
+    if (typeof options.transformUrl === "function") {
+      return getRouteMatches(branches(), options.transformUrl(location.pathname));
+    }
+
+    return getRouteMatches(branches(), location.pathname);
+  });
 
   const params = createMemoObject(() => {
     const m = matches();


### PR DESCRIPTION
This PR introduces a new feature allowing URL rewriting through a hook.

**New Prop Added:** A new property `transformUrl?: (url: string) => string` has been added to the `RouterProps` and `StaticRouterProps` types. This optional function allows developers to transform the URL before it is processed by the router.

**Routing Logic:** The Router function now checks for the presence of `transformUrl`. If provided, this function is used to alter the URL, allowing for scenarios such as URL rewriting:

Example: `/some-fancy-page.html` to `/product/123`

**Usage example with Solid Start, `app.tsx`:**

```tsx
// @refresh reload
import { Router } from "@solidjs/router";
import { FileRoutes } from "@solidjs/start/router";
import { Suspense } from "solid-js";

export default function App() {

  const rewriteMap: Record<string, string> = {
    "/some-fancy-keyboard.html": "/product/1",
    "/some-fancy-mouse.html": "/product/2",
    "/some-fancy-headset.html": "/product/3",
    "/u/ryan-carniato": "/user/1",
    "/u/jchatard": "/user/123",
    // ...
  };

  const rewrite = (url: string) => {
    // Of course can be what ever you want...
    const u = new URL(url, "http://localhost/");
    return rewriteMap[u.pathname] ? rewriteMap[u.pathname] + u.search : url;
  };

  return (
    <Router
      transformUrl={rewrite}
      root={(props) => <Suspense>{props.children}</Suspense>}
    >
      <FileRoutes />
    </Router>
  );
}
```

I couldn't figure out how to implement tests, sorry about that.
I would love to have feedbacks on this. And maybe `transformUrl` is not the greatest name. Happy to chat about that. 

Cheers,
Jérémy