### PR TITLE
Re-Export RouterContext for more control

### DIFF
--- a/.changeset/angry-mugs-brush.md
+++ b/.changeset/angry-mugs-brush.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": minor
+---
+
+Re-export context

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -2,6 +2,7 @@
 import type { JSX } from "solid-js";
 import { createMemo, mergeProps, splitProps } from "solid-js";
 import {
+  RouterContextObj,
   useHref,
   useLocation,
   useNavigate,
@@ -12,6 +13,8 @@ import type {
   Navigator
 } from "./types.js";
 import { normalizePath } from "./utils.js";
+
+export { RouterContextObj as RouterContext };
 
 declare module "solid-js" {
   namespace JSX {


### PR DESCRIPTION
### The problem
I develop a PWA mobile-first application based on solid start.

I liked the prefetch behaviour while debugging the app in my laptop environment, so when you hover any link, the resources of that route are being downloaded, so no FUOC happens when you click the link.

However, when I tested the app on my phone, I noticed the flash of unstyled content instantly.

### First approach
As first approach after looking through the code of solid router, I tried to emulate mouseover event on page load, for all the links found onMount. However, I see it as a big mistake

### Proposed solution
I recommend to re-export the context, as it has all the neccessary data and methods to programmatically preload routes, instead of making another bad solution.