### PR TITLE
Fix no-revalidate from server action

### DIFF
--- a/.changeset/thin-baboons-kiss.md
+++ b/.changeset/thin-baboons-kiss.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Fix no-revalidate from server action

--- a/src/data/action.ts
+++ b/src/data/action.ts
@@ -149,7 +149,9 @@ async function handleResponse(response: unknown, error: boolean | undefined, nav
   let flightKeys: string[] | undefined;
   if (response instanceof Response) {
     if (response.headers.has("X-Revalidate"))
-      keys = response.headers.get("X-Revalidate")!.split(",");
+      keys = response.headers.get("X-Revalidate")
+        ? response.headers.get("X-Revalidate")!.split(",")
+        : [];
     if ((response as any).customBody) {
       data = custom = await (response as any).customBody();
       if (response.headers.has("X-Single-Flight")) {


### PR DESCRIPTION
When `action` returns
```tsx
  return json(data, { revalidate: [] })
```

Empty revalidation keys array is serialised into an empty string, so `response.headers.get("X-Revalidate") === ''`.
This makes

https://github.com/solidjs/solid-router/blob/57847624fb673003f6f0d8261ca7352ff00e7480/src/data/action.ts#L152

to be an array of `['']` ([Playground](https://playground.solidjs.com/anonymous/7658a2ef-8611-4916-a007-715038b008a4)), causing all cache keys to be revalidated.

This PR adds empty string check, defaulting to an empty array, as empty array seem to correctly stop revalidation from happening.

Very subtle behaviour that should be tested, but I couldn't find a setup for `actions` testing.