### PR TITLE
fix: hash router state reset with `replace: false`

### DIFF
--- a/.changeset/nine-chefs-yawn.md
+++ b/.changeset/nine-chefs-yawn.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Fix `HashRouter` state reset with `replace: false`

--- a/src/routers/HashRouter.ts
+++ b/src/routers/HashRouter.ts
@@ -27,7 +27,7 @@ export function HashRouter(props: HashRouterProps): JSX.Element {
       if (replace) {
         window.history.replaceState(keepDepth(state), "", "#" + value);
       } else {
-        window.location.hash = value;
+        window.history.pushState(state, "", "#" + value);
       }
       const hashIndex = value.indexOf("#");
       const hash = hashIndex >= 0 ? value.slice(hashIndex + 1) : "";


### PR DESCRIPTION
Prior to `v0.13.3`, it seems the router source value was triggered twice when navigating between different `paths`.

In the first run, `next` has both `path + state` values, and in the second run, it has only the `path` value:

https://github.com/solidjs/solid-router/blob/57847624fb673003f6f0d8261ca7352ff00e7480/src/routers/createRouter.ts#L39-L42

<br>

It seems after introducing the state detection fix at #405, it surfaced this behavior — see #416 issue:

https://github.com/solidjs/solid-router/blob/57847624fb673003f6f0d8261ca7352ff00e7480/src/routing.ts#L344-L358

As the `start` function was only running once as the `path` hasn't changed in the second run. But now `start` runs twice which causes the `state` to reset to `undefined` unexpectedly.

<br>

I've noticed the behavior is different when setting `replace: true` while navigating. Changing the `HashRouter` `set` function to use `window.history.pushState(...)` seems to fix it for `replace: false` (default):

https://github.com/solidjs/solid-router/blob/57847624fb673003f6f0d8261ca7352ff00e7480/src/routers/HashRouter.ts#L27-L31

```diff
-         window.location.hash = value;
+         window.history.pushState(state, "", "#" + value);
```

Closes #416