### PR TITLE
Components consuming load functions no longer need non-null assertions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -77,7 +77,7 @@ export type RouteLoadFunc<T = unknown> = (args: RouteLoadFuncArgs) => T;
 export interface RouteSectionProps<T = unknown> {
   params: Params;
   location: Location;
-  data?: T;
+  data: T;
   children?: JSX.Element;
 }
 


### PR DESCRIPTION
Currently, load functions are clumsy to use from TypeScript because the `RouteSectionProps` type marks the `data` prop as optional. If you try working around that in your component (such as `Component<Required<RouteSectionProps<MyProps>>>)`, you instead get compile errors that your component's props type isn't assignable to `RouteDefinition`.

The only workaround I've found is runtime null checks or type-level non-null assertions, at every call site that touches the `data` prop inside a component.

This PR marks the `data` prop as non-optional: the route props will always have a `data` field, set to the `RouteSectionProps` generic parameter type. If not load function is supplied, the field's value would be `undefined`, with a type of `unknown`.

What happens if the route _doesn't have_ a load function defined? Your component would be declared as `Component<RouteSectionProps>`. Without the type param supplied, the `data` prop receives type `unknown`, and is unusable inside your component.

If a component sometimes does/doesn't receive load data, it can use `Component<RouteSectionProps<Foo | undefined>>`.

This approach provides accurate types when you have a load function, and still signals the `data` prop cannot be read when you do not have a load function.