### PR TITLE
Add `useMatches` hook to expose router matches

### DIFF
--- a/.changeset/silent-countries-mate.md
+++ b/.changeset/silent-countries-mate.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Add `useMatches` hook to expose router matches

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ export {
   useIsRouting,
   useLocation,
   useMatch,
+  useMatches,
   useCurrentMatches,
   useNavigate,
   useParams,

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -93,6 +93,8 @@ export const useMatch = <S extends string>(path: () => S, matchFilters?: MatchFi
 
 export const useCurrentMatches = () => useRouter().matches();
 
+export const useMatches = () => useRouter().matches;
+
 export const useParams = <T extends Params>() => useRouter().params as T;
 
 export const useSearchParams = <T extends Params>(): [


### PR DESCRIPTION
This PR adds a new `useMatches` hook which exposes the router's matches.

## Usecase

I think this is very useful for implementing a breadcrumb system.

Our pages have something along the lines of:
```ts
export const route = {
   info: {
      title: "Route A"
   }
}
```

and then with the `useMatches` hook this PR implements, our breadcrumb component can be implemented as such:
```tsx
import { useMatches } from "@solid/router";
import { createMemo } from "solid-js";

function BreadCrumb() {
   const matches = useMatches();

   // We iterate over each of the matches pulling out the `title` defined on the route as shown in the previous code.
   const routeTitles = createMemo(() =>
      [...matches()]
         .reverse()
         .find((m) => Array.isArray(m.route.info?.title || "")),
   );

   return (
      <div>
         <For each={routeTitles()}>
            {({ route }) => (
               <div>{route.info.title}</div>
            )}
         </For>
      </div>
   );
}
```

We are actively using these changes in our codebase and it would be really nice to upstream these changes so we don't require a fork. The codebase is open source if it provides more context to our usage. The [Breadcrumb component](https://github.com/mattrax/Mattrax/blob/d5aaec5e1bed4bcefb74d58c32364707541450c4/apps/web/src/components/Breadcrumbs.tsx#L15) and an example [`route export`](https://github.com/mattrax/Mattrax/blob/d5aaec5e1bed4bcefb74d58c32364707541450c4/apps/web/src/app/(dash)/account.tsx#L15).

## Prior Art

[React Router](https://reactrouter.com) has a similar feature [useMatches](https://reactrouter.com/en/main/hooks/use-matches). These docs even showcase a [Breadcrumb](https://reactrouter.com/en/main/hooks/use-matches#breadcrumbs) system similar to what I show above.