### PR TITLE
Mark touchstart event listener passive

### DIFF
--- a/.changeset/passive-touchstart.md
+++ b/.changeset/passive-touchstart.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Use passive touchstart event handler

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -140,7 +140,7 @@ export function setupNativeEvents(preload = true, explicitLinks = false, actionB
       document.addEventListener("mouseover", handleAnchorIn);
       document.addEventListener("mouseout", handleAnchorOut);
       document.addEventListener("focusin", handleAnchorPreload);
-      document.addEventListener("touchstart", handleAnchorPreload);
+      document.addEventListener("touchstart", handleAnchorPreload, { passive: true });
     }
     document.addEventListener("submit", handleFormSubmit);
     onCleanup(() => {


### PR DESCRIPTION
We don't call `preventDefault` in the handler, so marking it as passive event handler to improve scrolling performance