### PR TITLE
Make useCurrentMatches a getter function

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,7 +868,7 @@ return <div classList={{ active: Boolean(match()) }} />;
 For example if you stored breadcrumbs on your route definition you could retrieve them like so:
 ```js
 const matches = useCurrentMatches();
-const breadcrumbs = createMemo(() => matches.map(m => m.route.info.breadcrumb))
+const breadcrumbs = createMemo(() => matches().map(m => m.route.info.breadcrumb))
 ```
 
 ### useBeforeLeave

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -91,7 +91,7 @@ export const useMatch = <S extends string>(path: () => S, matchFilters?: MatchFi
   });
 };
 
-export const useCurrentMatches = () => useRouter().matches();
+export const useCurrentMatches = () => useRouter().matches;
 
 export const useParams = <T extends Params>() => useRouter().params as T;
 


### PR DESCRIPTION
`useCurrentMatches` should return a getter function like `useIsRouting`, `useMatches`, etc.

Closes #425 