### PR TITLE
Fixes #434 - Export type Route as RouteInfo

### DIFF
--- a/.changeset/many-shirts-tie.md
+++ b/.changeset/many-shirts-tie.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": minor
+---
+
+Fix #434 - export type Route as RouteInfo

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,7 @@ export type {
   RouteLoadFunc,
   RouteLoadFuncArgs,
   RouteDefinition,
-  Route,
+  Route as RouteInfo,  
   RouteMatch,
   RouterIntegration,
   RouterUtils,


### PR DESCRIPTION
Fixes #434 

Unfortunately in #432, the exported type and value `Route` did not merge correctly, breaking the library. It is possible to re-export them under the same name, but since the `Route` type was not part of the public API before renaming it seems cleaner.

I chose `RouteInfo` as the new exported name for the type.

If you prefer, I could rename type `Route` globally in the project instead of just the export.
