### PR TITLE
Forward absolute redirects inside `cache` from server to client

### DIFF
--- a/.changeset/breezy-trainers-marry.md
+++ b/.changeset/breezy-trainers-marry.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Forward absolute redirects inside `cache` from server to client


### PR DESCRIPTION
Currently, absolute redirects done inside `cache` on the server are (funnily enough) only performed when the cached function is also called inside `load`. I'm not exactly sure how `load` is involved to make that the case, but this PR seems to fix it.

Instead of server-side absolute redirects just being ignored in `handleResponse` by an early return, which results in the redirect Response not being serialized and processed on the client inside `cache`, the early return will only be done if the response has actually been handled. This change results in `load` not having any effect on the redirect behaviour, and absolute redirects will always be passed through from the server to be handled on the client.

Forcing absolute redirects onto the client works fine and avoids any CORS cross-origin redirect problems, but should there be an option for server-side absolute redirects to be properly supported?

Closes #438