### PR TITLE
Treat `window.location.hash` as URI encoded

### DIFF
--- a/.changeset/green-mice-build.md
+++ b/.changeset/green-mice-build.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Treat `window.location.hash` as URI encoded

--- a/src/routers/Router.ts
+++ b/src/routers/Router.ts
@@ -26,7 +26,7 @@ export function Router(props: RouterProps): JSX.Element {
       } else {
         window.history.pushState(state, "", value);
       }
-      scrollToHash(window.location.hash.slice(1), scroll);
+      scrollToHash(decodeURIComponent(window.location.hash.slice(1)), scroll);
       saveCurrentDepth();
     },
     init: notify => bindEvent(window, "popstate",


### PR DESCRIPTION
`window.location.hash` is URI encoded, but not HTML element ids, so the element lookup for scrollToHash fails when the has contains characters affected by URI encoding.

Closes #421