### PR TITLE
Fix 'Nested Routes' docs formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,8 +372,10 @@ You can nest indefinitely - just remember that only leaf nodes will become their
       </div>
     }
   >
-    <Route path="layer2"
-      component={() => <div>Innermost layer</div>}>           </Route>
+    <Route
+      path="layer2"
+      component={() => <div>Innermost layer</div>}
+    />
   </Route>
 </Route>
 ```


### PR DESCRIPTION
This formatting issue leads to a blank space being inserted which [breaks the route config](https://github.com/solidjs/solid-router/discussions/443)