### PR TITLE
Handle absolute redirects within `cache` on server

### DIFF
--- a/.changeset/blue-rules-drum.md
+++ b/.changeset/blue-rules-drum.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Handle absolute redirects within `cache` on server

--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -176,10 +176,14 @@ export function cache<T extends (...args: any) => any>(fn: T, name: string): Cac
               startTransition(() => {
                 navigate(url, { replace: true });
               });
-            // client-only absolute redirect (possibly cross-origin)
-            else if (!isServer && url) window.location.href = url;
-            // server-only absolute redirects are handled on the client
-            else if (isServer) returnEarly = false;
+            // client absolute redirect
+            else if (!isServer) window.location.href = url;
+            // server absolute redirects
+            else if (isServer) {
+              const e = getRequestEvent();
+              if (e) e.response = { status: 302, headers: new Headers({ Location: url }) };
+              return;
+            }
 
             if (returnEarly) return;
           }

--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -169,8 +169,6 @@ export function cache<T extends (...args: any) => any>(fn: T, name: string): Cac
           const url = v.headers.get(LocationHeader);
 
           if (url !== null) {
-            let returnEarly = true;
-
             // client + server relative redirect
             if (navigate && url.startsWith("/"))
               startTransition(() => {
@@ -180,10 +178,9 @@ export function cache<T extends (...args: any) => any>(fn: T, name: string): Cac
             else if (isServer) {
               const e = getRequestEvent();
               if (e) e.response = { status: 302, headers: new Headers({ Location: url }) };
-              return;
             }
 
-            if (returnEarly) return;
+            return;
           }
 
           if ((v as any).customBody) v = await (v as any).customBody();

--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -176,9 +176,7 @@ export function cache<T extends (...args: any) => any>(fn: T, name: string): Cac
               startTransition(() => {
                 navigate(url, { replace: true });
               });
-            // client absolute redirect
             else if (!isServer) window.location.href = url;
-            // server absolute redirects
             else if (isServer) {
               const e = getRequestEvent();
               if (e) e.response = { status: 302, headers: new Headers({ Location: url }) };


### PR DESCRIPTION
Follows on from #439, handling absolute redirects properly on the server instead of letting them be handled on the client.
This just takes the server redirect implementation in `navigateFromRoute` and puts it in `handleResponse`.