### PR TITLE
add delay to useBeforeLeave retry function

### DIFF
--- a/.changeset/shy-turkeys-give.md
+++ b/.changeset/shy-turkeys-give.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+add delay to useBeforeLeave retry function

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -24,7 +24,7 @@ export function createBeforeLeave(): BeforeLeaveLifecycle {
         from: l.location,
         retry: (force?: boolean) => {
           force && (ignore = true);
-          l.navigate(to as string, {...options, resolve: false});
+          setTimeout(() => l.navigate(to as string, {...options, resolve: false}), 10);
         }
       });
     return !e.defaultPrevented;


### PR DESCRIPTION
The useBeforeLeave feature hacks around the fact that u can't prevent browser back/forward navigation, using window.history.go(-1 or 1) to counter the initial direction and go back.

During development I found that window.history.go() can't be called too many times at once or else it doesn't navigate at all.

This behaviour causes a bug when using e.preventDefault() and e.retry(true) together (it changes the url the first time but doesn't render, after this the depth property in the history state is inaccurate and causes further breakage.

Adding a small delay like this would prevent this particular thing from happening.