### PR TITLE
Support temporary `latest` field for `createAsync` and `createAsyncStore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,11 +495,19 @@ This is light wrapper over `createResource` that aims to serve as stand-in for a
 const user = createAsync((currentValue) => getUser(params.id))
 ```
 
+It also preserves `latest` field from `createResource`. Note that it will be removed in the future.
+
+```jsx
+const user = createAsync((currentValue) => getUser(params.id))
+return <h1>{user.latest.name}</h1>;
+```
+
 Using `cache` in `createResource` directly won't work properly as the fetcher is not reactive and it won't invalidate properly.
 
 ### `createAsyncStore`
 
 Similar to `createAsync` except it uses a deeply reactive store. Perfect for applying fine-grained changes to large model data that updates.
+It also supports `latest` field which will be removed in the future.
 
 ```jsx
 const todos = createAsyncStore(() => getTodos());

--- a/src/data/createAsync.ts
+++ b/src/data/createAsync.ts
@@ -10,7 +10,7 @@ import { isServer } from "solid-js/web";
  * this type allows to support `latest` field for these primitives.
  * It will be removed in the future.
  */
-type AccessorWithLatest<T> = {
+export type AccessorWithLatest<T> = {
   (): T;
   latest: T;
 }

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,4 +1,4 @@
-export { createAsync, createAsyncStore } from "./createAsync.js";
+export { createAsync, createAsyncStore, type AccessorWithLatest } from "./createAsync.js";
 export { action, useSubmission, useSubmissions, useAction, type Action } from "./action.js";
 export { cache, revalidate, type CachedFunction } from "./cache.js";
 export { redirect, reload, json } from "./response.js";


### PR DESCRIPTION
This PR adds support for `latest` field for `createAsync` and `createAsyncStore` for compatibility with `createResource`.

**MOTIVATION**

At the moment `createAsync` and `createAsyncStore` are just wrappers for `createResource`. `createResource` provides the mechanism to avoid triggering `Suspense`, which is quite useful in some cases.

In order to improve adoption of `createAsync` and `createAsyncStore` it would be useful to provide this mechanism also for these primitives.

In the future major release of solid support of the `latest` field (and `createResource`) will be dropped in favor of `createAsync` and `createAsyncStore`. `.latest` could be replaced with `latest(...)` helper (TBD) or could be dropped at all. In both cases the migration will be simple:
- Replaced with `latest(...)` helper: `data.latest` => `latest(data)`
- Dropped support of `.latest` field: `data.latest` => `data`

At the moment lack of `.latest` support for `createAsync` and `createAsyncStore` prevents people from wide adoption of these primitives. Moreover, people start invent some hacks like [this](https://discord.com/channels/722131463138705510/722131463889223772/1264787694614085683) which consume much more memory.