### PR TITLE
feat: Wire useSearchParams to url rewriting

### DIFF
--- a/.changeset/tricky-rats-raise.md
+++ b/.changeset/tricky-rats-raise.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+feat: Wire useSearchParams to url rewriting

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -8,7 +8,7 @@ export function setupNativeEvents(
   preload = true,
   explicitLinks = false,
   actionBase = "/_server",
-  transformUrl?: (url: string) => string
+  rewritePathToRoute?: (url: string) => string
 ) {
   return (router: RouterContext) => {
     const basePath = router.base.path();
@@ -76,8 +76,8 @@ export function setupNativeEvents(
       const res = handleAnchor(evt as MouseEvent);
       if (!res) return;
       const [a, url] = res;
-      if (typeof transformUrl === "function") {
-        url.pathname = transformUrl(url.pathname);
+      if (typeof rewritePathToRoute === "function") {
+        url.pathname = rewritePathToRoute(url.pathname);
       }
       if (!preloadTimeout[url.pathname])
         router.preloadRoute(url, { preloadData: a.getAttribute("preload") !== "false" });
@@ -87,8 +87,8 @@ export function setupNativeEvents(
       const res = handleAnchor(evt as MouseEvent);
       if (!res) return;
       const [a, url] = res;
-      if (typeof transformUrl === "function") {
-        url.pathname = transformUrl(url.pathname);
+      if (typeof rewritePathToRoute === "function") {
+        url.pathname = rewritePathToRoute(url.pathname);
       }
       if (preloadTimeout[url.pathname]) return;
       preloadTimeout[url.pathname] = setTimeout(() => {
@@ -101,8 +101,8 @@ export function setupNativeEvents(
       const res = handleAnchor(evt as MouseEvent);
       if (!res) return;
       const [, url] = res;
-      if (typeof transformUrl === "function") {
-        url.pathname = transformUrl(url.pathname);
+      if (typeof rewritePathToRoute === "function") {
+        url.pathname = rewritePathToRoute(url.pathname);
       }
       if (preloadTimeout[url.pathname]) {
         clearTimeout(preloadTimeout[url.pathname]);

--- a/src/routers/Router.ts
+++ b/src/routers/Router.ts
@@ -13,7 +13,9 @@ export function Router(props: RouterProps): JSX.Element {
   const getSource = () => {
     const url = window.location.pathname.replace(/^\/+/, "/") + window.location.search;
     return {
-      value: props.transformUrl ? props.transformUrl(url) + window.location.hash : url + window.location.hash,
+      value: props.rewritePathToRoute
+        ? props.rewritePathToRoute(url) + window.location.hash
+        : url + window.location.hash,
       state: window.history.state
     }
   };
@@ -39,7 +41,12 @@ export function Router(props: RouterProps): JSX.Element {
           }
         })
       ),
-    create: setupNativeEvents(props.preload, props.explicitLinks, props.actionBase, props.transformUrl),
+    create: setupNativeEvents(
+      props.preload,
+      props.explicitLinks,
+      props.actionBase,
+      props.rewritePathToRoute
+    ),
     utils: {
       go: delta => window.history.go(delta),
       beforeLeave

--- a/src/routers/StaticRouter.ts
+++ b/src/routers/StaticRouter.ts
@@ -13,7 +13,7 @@ export function StaticRouter(props: StaticRouterProps): JSX.Element {
   let e;
   const url = props.url || ((e = getRequestEvent()) && getPath(e.request.url)) || ""
   const obj = {
-    value: props.transformUrl ? props.transformUrl(url) : url,
+    value: props.rewritePathToRoute ? props.rewritePathToRoute(url) : url
   };
   return createRouterComponent({
     signal: [() => obj, next => Object.assign(obj, next)]

--- a/src/routers/components.tsx
+++ b/src/routers/components.tsx
@@ -42,9 +42,12 @@ export type BaseRouterProps = {
   rootPreload?: RoutePreloadFunc;
   singleFlight?: boolean;
   children?: JSX.Element | RouteDefinition | RouteDefinition[];
-  transformUrl?: (url: string) => string;
+  rewritePathToRoute?: (url: string) => string;
+  rewriteRouteToPath?: (url: string) => string;
   /** @deprecated use rootPreload */
   rootLoad?: RoutePreloadFunc;
+  /** @deprecated  use rewritePathToRoute */
+  transformUrl?: (url: string) => string;
 };
 
 export const createRouterComponent = (router: RouterIntegration) => (props: BaseRouterProps) => {
@@ -58,7 +61,7 @@ export const createRouterComponent = (router: RouterIntegration) => (props: Base
   const routerState = createRouterContext(router, branches, () => context, {
     base,
     singleFlight: props.singleFlight,
-    transformUrl: props.transformUrl,
+    rewritePathToRoute: props.rewritePathToRoute || props.transformUrl
   });
   router.create && router.create(routerState);
   return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,7 +171,11 @@ export interface RouterContext {
   beforeLeave: BeforeLeaveLifecycle;
   preloadRoute: (url: URL, options: { preloadData?: boolean }) => void;
   singleFlight: boolean;
+  rewritePathToRoute?: (url: string) => string;
+  rewriteRouteToPath?: (url: string) => string;
   submissions: Signal<Submission<any, any>[]>;
+  /** @deprecated  use rewritePathToRoute */
+  transformUrl?: (url: string) => string;
 }
 
 export interface BeforeLeaveEventArgs {


### PR DESCRIPTION
This is a follow up on [feat: add URL transformation hook](https://github.com/solidjs/solid-router/pull/410)

My implementation of URL rewriting was working great until I tried using `useSearchParams` setter which would update the browser's URL to the route:

From: `/foo.html?bar=baz` updating `bar` to `biz`
Result: `/product/123?bar=biz`
Expected: `/foo.html?bar=biz`

So I needed  to wire it, but the logic is reversed, compared to the previous PR.

- `transformUrl` transforms incoming requests pathname to router's route.
- for `useSearchParams` setter we the need the opposite, from a route displaying the rewritten url in the browser.

So to make this reversed behavior clearer, I renamed `transformUrl` (with a deprecation notice, even though I'm pretty sure I'm the only one using rewrites :-) ) to `rewritePathToRoute` and introduced `rewriteRouteToPath`.

I plan to write some doc at some point, but I might be still missing some rewrite wiring here and there.

And you implement it like this:

```tsx
const pathnameToRoute = (url: string) => {
    const u = new URL(url, "http://localhost/");
    return rewriteMap[u.pathname] ? rewriteMap[u.pathname] + u.search : url;
  };

  const routeToPathname = (url: string) => {
    const u = new URL(url, "http://localhost/");
    if (Object.values(rewriteMap).includes(url)) {
      const swapped = swapKeyValue(rewriteMap);
      return swapped[u.pathname] + u.search;
    }
    return url;
  };

  return (
    <Router
      explicitLinks={true}
      preload={false}
      rewritePathToName={pathnameToRoute}
      rewriteRouteToPath={routeToPathname}
      root={(props) => (
        <Suspense>
          <RootContexts>{props.children}</RootContexts>
        </Suspense>
      )}
      rootPreload={() => {
        getMenuMain();
        getMenuFooter();
        getSettings();
      }}
    >
      <FileRoutes />
    </Router>
  );
```

Let me know what you think!

Thank you!
Jérémy