### PR TITLE
feat: Make useSearchParams work with URL rewriting on the client

### DIFF
--- a/.changeset/late-buses-melt.md
+++ b/.changeset/late-buses-melt.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Make useSearchParams work with URL rewriting on the client.

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -104,7 +104,7 @@ export const useSearchParams = <T extends Params>(): [
   const navigate = useNavigate();
   const setSearchParams = (params: SetParams, options?: Partial<NavigateOptions>) => {
     const searchString = untrack(
-      () => location.pathname + mergeSearchString(location.search, params) + location.hash
+      () => isServer ? location.pathname : window.location.pathname + mergeSearchString(location.search, params) + location.hash
     );
     navigate(searchString, {
       scroll: false,


### PR DESCRIPTION
This is a much simpler implementation of [feat: Wire useSearchParams to url rewriting](https://github.com/solidjs/solid-router/pull/465).

- It doesn't need a second hook to reverse the mapping.
- It doesn't touch the ```navigate``` logic, which, to be honest, I don't fully grasp.

It might be a bit less agnostic, but I can't find a scenario where this could break, given the purpose of the ```useSearchParams``` setter.

I guess a cleaner solution might be to move this to the integration level...

In React Router, they seem to allow ```navigate()``` to take a string like this: ```?foo=bar``` and then append it to the current location pathname. But I'm not sure, as I have never used it.