### PR TITLE
feat: Add customSetup for routers to override "NativeEvents"

### DIFF
--- a/src/routers/HashRouter.ts
+++ b/src/routers/HashRouter.ts
@@ -40,7 +40,7 @@ export function HashRouter(props: HashRouterProps): JSX.Element {
           delta => !beforeLeave.confirm(delta && delta < 0 ? delta : getSource())
         )
       ),
-    create: setupNativeEvents(props.preload, props.explicitLinks, props.actionBase),
+    create: props.customSetup ? props.customSetup(props) : setupNativeEvents(props.preload, props.explicitLinks, props.actionBase),
     utils: {
       go: delta => window.history.go(delta),
       renderPath: path => `#${path}`,

--- a/src/routers/MemoryRouter.ts
+++ b/src/routers/MemoryRouter.ts
@@ -68,7 +68,7 @@ export function MemoryRouter(props: MemoryRouterProps): JSX.Element {
     get: memoryHistory.get,
     set: memoryHistory.set,
     init: memoryHistory.listen,
-    create: setupNativeEvents(props.preload, props.explicitLinks, props.actionBase),
+    create: props.customSetup ? props.customSetup(props) : setupNativeEvents(props.preload, props.explicitLinks, props.actionBase),
     utils: {
       go: memoryHistory.go
     }

--- a/src/routers/Router.ts
+++ b/src/routers/Router.ts
@@ -39,7 +39,7 @@ export function Router(props: RouterProps): JSX.Element {
           }
         })
       ),
-    create: setupNativeEvents(props.preload, props.explicitLinks, props.actionBase, props.transformUrl),
+    create: props.customSetup ? props.customSetup(props) : setupNativeEvents(props.preload, props.explicitLinks, props.actionBase, props.transformUrl),
     utils: {
       go: delta => window.history.go(delta),
       beforeLeave

--- a/src/routers/components.tsx
+++ b/src/routers/components.tsx
@@ -43,6 +43,7 @@ export type BaseRouterProps = {
   singleFlight?: boolean;
   children?: JSX.Element | RouteDefinition | RouteDefinition[];
   transformUrl?: (url: string) => string;
+  customSetup?: (props: BaseRouterProps) => (router: RouterContext) => void;
   /** @deprecated use rootPreload */
   rootLoad?: RoutePreloadFunc;
 };


### PR DESCRIPTION
Hey @ryansolid - For devices that aren't web based and using universal renderer - I'd like to have a customSetup function to override the default "nativeSetup" (as we don't use a mouse pointer). Just want to get your initial feedback before I do it to the other routers as well.