### PR TITLE
Fix duplicated push history

### DIFF
--- a/.changeset/duplicated-history-push.md
+++ b/.changeset/duplicated-history-push.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Fix duplicated push history

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -68,7 +68,7 @@ export function setupNativeEvents(
         resolve: false,
         replace: a.hasAttribute("replace"),
         scroll: !a.hasAttribute("noscroll"),
-        state: state && JSON.parse(state)
+        state: state ? JSON.parse(state) : undefined
       });
     }
 


### PR DESCRIPTION
Fix #479

From debugging, it seems that we are changing the state to `undefined` here, while the state set from click events from anchor tags are from `getAttribute` which uses `null`, so the states are always different

https://github.com/solidjs/solid-router/blob/24dbf2c80bc9c73e5bffae621a4634cc9f46fa51/src/routers/Router.ts#L15-L19