### PR TITLE
Fix scrollToHash to handle hashes starting with a number

### DIFF
--- a/.changeset/hungry-trees-explode.md
+++ b/.changeset/hungry-trees-explode.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Fix scrollToHash to handle hashes starting with a number

--- a/src/routers/createRouter.ts
+++ b/src/routers/createRouter.ts
@@ -65,7 +65,7 @@ export function bindEvent(target: EventTarget, type: string, handler: EventListe
 }
 
 export function scrollToHash(hash: string, fallbackTop?: boolean) {
-  const el = querySelector(`#${hash}`);
+  const el = querySelector(`#${hash}`) ?? document.getElementById(hash);
   if (el) {
     el.scrollIntoView();
   } else if (fallbackTop) {


### PR DESCRIPTION
When hash starts with a number, `document.querySelector` throws an error, causing `scrollToHash` to fail.

![](https://github.com/user-attachments/assets/1fa7e61a-686c-4c46-ba38-79fefde301ec)
