### PR TITLE
fix active detection for url's containing international characters

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -51,7 +51,7 @@ export function A(props: AnchorProps) {
     const to_ = to();
     if (to_ === undefined) return [false, false];
     const path = normalizePath(to_.split(/[?#]/, 1)[0]).toLowerCase();
-    const loc = normalizePath(location.pathname).toLowerCase();
+    const loc = decodeURI(normalizePath(location.pathname).toLowerCase());
     return [props.end ? path === loc : loc.startsWith(path + "/") || loc === path, path === loc];
   });
 


### PR DESCRIPTION
The active/inactive classes don't apply correctly for URL's containing international characters, as the location is URL-encoded while the path passed to the component is not. This is one way to make it work, the alternatives being to encode the path coming in, or to decode the location everywhere (which I would personally like to see but would be a larger change). Not sure which is preferred.