### PR TITLE
fix: add missing exports to recreate Routers

### DIFF
--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -1,6 +1,6 @@
 export { Route } from "./components.jsx";
 export type { BaseRouterProps, RouteProps } from "./components.jsx";
-export { createRouter } from "./createRouter.js";
+export { createRouter, bindEvent, scrollToHash } from "./createRouter.js";
 export { Router } from "./Router.js";
 export type { RouterProps } from "./Router.js";
 export { HashRouter } from "./HashRouter.js";


### PR DESCRIPTION
When trying to tweak HashRouter there were some missing exports. Adding those in.