### PR TITLE
feat(search-params): Enable arrays in useSearchParams

### DIFF
--- a/src/routing.ts
+++ b/src/routing.ts
@@ -32,7 +32,9 @@ import type {
   RouterContext,
   RouterIntegration,
   SetParams,
-  Submission
+  Submission,
+  SearchParams,
+  SetSearchParams
 } from "./types.js";
 import {
   mockBase,
@@ -96,13 +98,13 @@ export const useCurrentMatches = () => useRouter().matches;
 
 export const useParams = <T extends Params>() => useRouter().params as T;
 
-export const useSearchParams = <T extends Params>(): [
+export const useSearchParams = <T extends SearchParams>(): [
   Partial<T>,
-  (params: SetParams, options?: Partial<NavigateOptions>) => void
+  (params: SetSearchParams, options?: Partial<NavigateOptions>) => void
 ] => {
   const location = useLocation();
   const navigate = useNavigate();
-  const setSearchParams = (params: SetParams, options?: Partial<NavigateOptions>) => {
+  const setSearchParams = (params: SetSearchParams, options?: Partial<NavigateOptions>) => {
     const searchString = untrack(() => mergeSearchString(location.search, params) + location.hash);
     navigate(searchString, {
       scroll: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,9 +5,9 @@ declare module "solid-js/web" {
     response: {
       status?: number;
       statusText?: string;
-      headers: Headers
+      headers: Headers;
     };
-    router? : {
+    router?: {
       matches?: OutputMatch[];
       cache?: Map<string, CacheEntry>;
       submission?: {
@@ -18,14 +18,17 @@ declare module "solid-js/web" {
       dataOnly?: boolean | string[];
       data?: Record<string, any>;
       previousUrl?: string;
-    }
+    };
     serverOnly?: boolean;
   }
 }
 
-export type Params = Record<string, string>;
+export type Params = Record<string, string | string[]>;
 
-export type SetParams = Record<string, string | number | boolean | null | undefined>;
+export type SetParams = Record<
+  string,
+  string | string[] | number | number[] | boolean | boolean[] | null | undefined
+>;
 
 export interface Path {
   pathname: string;
@@ -227,7 +230,10 @@ export type NarrowResponse<T> = T extends CustomResponse<infer U> ? U : Exclude<
 export type RouterResponseInit = Omit<ResponseInit, "body"> & { revalidate?: string | string[] };
 // export type CustomResponse<T> = Response & { customBody: () => T };
 // hack to avoid it thinking it inherited from Response
-export type CustomResponse<T> = Omit<Response, "clone"> & { customBody: () => T; clone(...args: readonly unknown[]): CustomResponse<T> };
+export type CustomResponse<T> = Omit<Response, "clone"> & {
+  customBody: () => T;
+  clone(...args: readonly unknown[]): CustomResponse<T>;
+};
 
 /** @deprecated */
 export type RouteLoadFunc = RoutePreloadFunc;

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,9 +23,14 @@ declare module "solid-js/web" {
   }
 }
 
-export type Params = Record<string, string | string[]>;
+export type Params = Record<string, string>;
+export type SearchParams = Record<string, string | string[]>;
 
 export type SetParams = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+export type SetSearchParams = Record<
   string,
   string | string[] | number | number[] | boolean | boolean[] | null | undefined
 >;
@@ -37,7 +42,7 @@ export interface Path {
 }
 
 export interface Location<S = unknown> extends Path {
-  query: Params;
+  query: SearchParams;
   state: Readonly<Partial<S>> | null;
   key: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -172,6 +172,8 @@ export function mergeSearchString(search: string, params: SetSearchParams) {
       merged.delete(key);
     } else {
       if (value instanceof Array) {
+        // Delete all instances of the key before appending
+        merged.delete(key);
         value.forEach(v => {
           merged.append(key, String(v));
         });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,9 @@ import type {
   Params,
   PathMatch,
   RouteDescription,
-  SetParams
+  SearchParams,
+  SetParams,
+  SetSearchParams
 } from "./types.ts";
 
 const hasSchemeRegex = /^(?:[a-z0-9]+:)?\/\//i;
@@ -45,8 +47,8 @@ export function joinPaths(from: string, to: string): string {
   return normalizePath(from).replace(/\/*(\*.*)?$/g, "") + normalizePath(to);
 }
 
-export function extractSearchParams(url: URL): Params {
-  const params: Params = {};
+export function extractSearchParams(url: URL): SearchParams {
+  const params: SearchParams = {};
   url.searchParams.forEach((value, key) => {
     if (key in params) {
       params[key] = Array.isArray(params[key])
@@ -163,7 +165,7 @@ export function createMemoObject<T extends Record<string | symbol, unknown>>(fn:
   });
 }
 
-export function mergeSearchString(search: string, params: SetParams) {
+export function mergeSearchString(search: string, params: SetSearchParams) {
   const merged = new URLSearchParams(search);
   Object.entries(params).forEach(([key, value]) => {
     if (value == null || value === "" || (value instanceof Array && !value.length)) {

--- a/test/route.spec.ts
+++ b/test/route.spec.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { vi } from "vitest";
 import { createBranch, createBranches, createRoutes } from "../src/routing.js";
 import type { RouteDefinition } from "../src/index.js";
 
@@ -174,7 +174,6 @@ describe("createRoutes should", () => {
       expect(match).not.toBeNull();
       expect(match.path).toBe("/foo/123/bar/solid.html");
     });
-
   });
 
   describe(`expand optional parameters`, () => {

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -136,6 +136,12 @@ describe("mergeSearchString should", () => {
     const actual = mergeSearchString("?foo=2&foo=3", { foo: [] });
     expect(actual).toBe(expected);
   });
+
+  test("return array containing only new value when current is present and new is an array with one value", () => {
+    const expected = "?foo=1&foo=2";
+    const actual = mergeSearchString("?foo=3&foo=4", { foo: [1, 2] });
+    expect(actual).toBe(expected);
+  });
 });
 
 describe("extractSearchParams should", () => {

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -3,7 +3,9 @@ import {
   joinPaths,
   resolvePath,
   createMemoObject,
-  expandOptionals
+  expandOptionals,
+  mergeSearchString,
+  extractSearchParams
 } from "../src/utils";
 
 describe("resolvePath should", () => {
@@ -83,6 +85,79 @@ describe("resolvePath should", () => {
     const expected = "/ foo / bar baz ";
     const actual = resolvePath(" foo ", " bar baz ", "");
     expect(actual).toBe(expected);
+  });
+});
+
+describe("mergeSearchString should", () => {
+  test("return empty string when current and new params are empty", () => {
+    const expected = "";
+    const actual = mergeSearchString("", {});
+    expect(actual).toBe(expected);
+  });
+
+  test("return new params when current params are empty", () => {
+    const expected = "?foo=bar";
+    const actual = mergeSearchString("", { foo: "bar" });
+    expect(actual).toBe(expected);
+  });
+
+  test("return current params when new params are empty", () => {
+    const expected = "?foo=bar";
+    const actual = mergeSearchString("?foo=bar", {});
+    expect(actual).toBe(expected);
+  });
+
+  test("return merged params when current and new params are not empty", () => {
+    const expected = "?foo=bar&baz=qux";
+    const actual = mergeSearchString("?foo=bar", { baz: "qux" });
+    expect(actual).toBe(expected);
+  });
+
+  test("return ampersand-separated params when new params is an array", () => {
+    const expected = "?foo=bar&foo=baz";
+    const actual = mergeSearchString("", { foo: ["bar", "baz"] });
+    expect(actual).toBe(expected);
+  });
+
+  test("return ampersand-separated params when current params is an array of numbers", () => {
+    const expected = "?foo=1&foo=2";
+    const actual = mergeSearchString("", { foo: [1, 2] });
+    expect(actual).toBe(expected);
+  });
+
+  test("return empty string when new is an empty array", () => {
+    const expected = "";
+    const actual = mergeSearchString("", { foo: [] });
+    expect(actual).toBe(expected);
+  });
+
+  test("return empty string when current is present and new is an empty array", () => {
+    const expected = "";
+    const actual = mergeSearchString("?foo=2&foo=3", { foo: [] });
+    expect(actual).toBe(expected);
+  });
+});
+
+describe("extractSearchParams should", () => {
+  test("return empty object when URL has no search params", () => {
+    const url = new URL("http://localhost/");
+    const expected = {};
+    const actual = extractSearchParams(url);
+    expect(actual).toEqual(expected);
+  });
+
+  test("return search params as object", () => {
+    const url = new URL("http://localhost/?foo=bar&baz=qux");
+    const expected = { foo: "bar", baz: "qux" };
+    const actual = extractSearchParams(url);
+    expect(actual).toEqual(expected);
+  });
+
+  test("return search params as object with array values", () => {
+    const url = new URL("http://localhost/?foo=bar&foo=baz");
+    const expected = { foo: ["bar", "baz"] };
+    const actual = extractSearchParams(url);
+    expect(actual).toEqual(expected);
   });
 });
 


### PR DESCRIPTION
# The problem

I want to be able to add an array of values as a search parameter. It is supported using native [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) with the method `append`. It is also supported in [React Router](https://reactrouter.com/en/main/hooks/use-search-params) (you can see that in the type definition, and I've used it multiple times.).

## Desired behaviour

```ts
const [searchParams, setSearchParams] = useSearchParams();
setSearchParams({
    foo: ["bar", "bazz"]
})
```
This would result in `?foo=bar&foo=bazz`

# Proposed solution

In serialization check if input is array, then use the `append` method, else use the `set` method.
https://github.com/solidjs/solid-router/blob/b4f75446f802f6e11d5e07b8beb1e6bb9e096582/src/utils.ts#L172-L178
In deserialization, check if the key is already present. If yes, then transform the value into an array and append to it.
https://github.com/solidjs/solid-router/blob/b4f75446f802f6e11d5e07b8beb1e6bb9e096582/src/utils.ts#L50-L56

I also wrote a couple of tests to verify the behaviour.
