### PR TITLE
rename `cache` to `query`, action `onComplete`

### DIFF
--- a/.changeset/happy-actors-pretend.md
+++ b/.changeset/happy-actors-pretend.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+fix passing result into onComplete

--- a/.changeset/perfect-pears-look.md
+++ b/.changeset/perfect-pears-look.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": minor
+---
+
+rename `cache` to `query`, action `onComplete`

--- a/src/data/action.ts
+++ b/src/data/action.ts
@@ -3,7 +3,7 @@ import { isServer } from "solid-js/web";
 import { useRouter } from "../routing.js";
 import type { RouterContext, Submission, SubmissionStub, Navigator, NarrowResponse } from "../types.js";
 import { mockBase } from "../utils.js";
-import { cacheKeyOp, hashKey, revalidate, cache } from "./cache.js";
+import { cacheKeyOp, hashKey, revalidate, query } from "./query.js";
 
 export type Action<T extends Array<any>, U, V = T> = (T extends [FormData] | []
   ? JSX.SerializableAttributeValue
@@ -62,7 +62,15 @@ export function useAction<T extends Array<any>, U, V>(action: Action<T, U, V>) {
 export function action<T extends Array<any>, U = void>(
   fn: (...args: T) => Promise<U>,
   name?: string
-): Action<T, U, T> {
+): Action<T, U>
+export function action<T extends Array<any>, U = void>(
+  fn: (...args: T) => Promise<U>,
+  options?: { name?: string; onComplete?: (s: Submission<T, U>) => void }
+): Action<T, U>
+export function action<T extends Array<any>, U = void>(
+  fn: (...args: T) => Promise<U>,
+  options: string | { name?: string; onComplete?: (s: Submission<T, U>) => void } = {}
+): Action<T, U> {
   function mutate(this: { r: RouterContext; f?: HTMLFormElement }, ...variables: T) {
     const router = this.r;
     const form = this.f;
@@ -76,6 +84,7 @@ export function action<T extends Array<any>, U = void>(
     function handler(error?: boolean) {
       return async (res: any) => {
         const result = await handleResponse(res, error, router.navigatorFactory());
+        o.onComplete && o.onComplete(submission);
         if (!result) return submission.clear();
         setResult(result);
         if (result.error && !form) throw result.error;
@@ -108,10 +117,10 @@ export function action<T extends Array<any>, U = void>(
     ]);
     return p.then(handler(), handler(true));
   }
-
+  const o = typeof options === "string" ? { name: options } : options;
   const url: string =
     (fn as any).url ||
-    (name && `https://action/${name}`) ||
+    (o.name && `https://action/${o.name}`) ||
     (!isServer ? `https://action/${hashString(fn.toString())}` : "");
   mutate.base = url;
   return toAction(mutate, url);
@@ -177,7 +186,7 @@ async function handleResponse(response: unknown, error: boolean | undefined, nav
   // invalidate
   cacheKeyOp(keys, entry => (entry[0] = 0));
   // set cache
-  flightKeys && flightKeys.forEach(k => cache.set(k, custom[k]));
+  flightKeys && flightKeys.forEach(k => query.set(k, custom[k]));
   // trigger revalidation
   await revalidate(keys, false);
   return data != null ? { data } : undefined;

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,5 +1,5 @@
 export { createAsync, createAsyncStore, type AccessorWithLatest } from "./createAsync.js";
 export { action, useSubmission, useSubmissions, useAction, type Action } from "./action.js";
-export { cache, revalidate, type CachedFunction } from "./cache.js";
+export { query, revalidate, cache, type CachedFunction } from "./query.js";
 export { redirect, reload, json } from "./response.js";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -229,7 +229,7 @@ export interface MaybePreloadableComponent extends Component {
   preload?: () => void;
 }
 
-export type CacheEntry = [number, any, Intent | undefined, Signal<number> & { count: number }];
+export type CacheEntry = [number, Promise<any>, any, Intent | undefined, Signal<number> & { count: number }];
 
 export type NarrowResponse<T> = T extends CustomResponse<infer U> ? U : Exclude<T, Response>;
 export type RouterResponseInit = Omit<ResponseInit, "body"> & { revalidate?: string | string[] };


### PR DESCRIPTION
Proposed updates to Router APIs...

Mainly rename `cache` to `query`

Also add the `onComplete` API to submissions. That I brainstormed here: https://hackmd.io/@0u1u3zEAQAO0iYWVAStEvw/ry9vVctJkg