### PR TITLE
Export Submission at the top level

### DIFF
--- a/.changeset/cuddly-kangaroos-unite.md
+++ b/.changeset/cuddly-kangaroos-unite.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Export Submission at the top level

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,6 +35,7 @@ export type {
   RouterIntegration,
   RouterUtils,
   SetParams,
+  Submission,
   BeforeLeaveEventArgs,
   RouteLoadFunc,
   RouteLoadFuncArgs,


### PR DESCRIPTION
It's already accessible via `action` and `useSubmission`, it makes sense to export on its own.