### PR TITLE
Make useHref return a string with string param

### DIFF
--- a/src/routing.ts
+++ b/src/routing.ts
@@ -68,7 +68,7 @@ export const useResolvedPath = (path: () => string) => {
   return createMemo(() => route.resolvePath(path()));
 };
 
-export const useHref = (to: () => string | undefined) => {
+export const useHref = <T extends string | undefined>(to: () => T): string | T => {
   const router = useRouter();
   return createMemo(() => {
     const to_ = to();


### PR DESCRIPTION
This avoids the need to handle an undefined value when the destination parameter is known to be a string.