### PR TITLE
export SearchParams

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ export * from "./data/index.js";
 export type {
   Location,
   LocationChange,
+  SearchParams,
   MatchFilter,
   MatchFilters,
   NavigateOptions,


### PR DESCRIPTION
`SearchParams` is on `Location` which is already exported. This PR makes it so I don't have to do `Location['query']`, e.g.

```ts
import { type Location } from '@solidjs/router'

export const someFn = (search: Location['query']) => { ... }
```