### PR TITLE
fix(type): allow value from `Params` and `SearchParams` to be optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -23,8 +23,8 @@ declare module "solid-js/web" {
   }
 }
 
-export type Params = Record<string, string>;
-export type SearchParams = Record<string, string | string[]>;
+export type Params = Record<string, string | undefined>;
+export type SearchParams = Record<string, string | string[] | undefined>;
 
 export type SetParams = Record<
   string,


### PR DESCRIPTION
There is no way for us to know if these params is obligated or optional from the input. So it is safer to assume that they can be undefined.