### PR TITLE
remove ">" in the npm installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It supports all of Solid's SSR methods and has Solid's transitions baked in, so 
 ### Set Up the Router
 
 ```sh
-> npm i @solidjs/router
+npm i @solidjs/router
 ```
 
 Install `@solidjs/router`, then start your application by rendering the router component


### PR DESCRIPTION
remove > so the copied command will run correctly
if you run "> npm i @solidjs/router" you'll most likely get an error in all operating systems because of the ">".
the github code "Copy" button includes it, so its better removed for that reason.