### PR TITLE
Release 1.0.0

### DIFF
--- a/.changeset/green-peaches-yell.md
+++ b/.changeset/green-peaches-yell.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": major
+---
+
+release 1.0.0


### PR DESCRIPTION
The `@solidjs/router` API hasn't changed for about a year (since the SolidStart v1), same as Solid Meta, so it seems reasonable to stabilize the current api surface, and keep following semver with changesets like we do already.

Currently, the only stable SPA router for solid is `@tanstack/solid-router`.