### PR TITLE
fix ci release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test": "vitest run && npm run test:types",
     "test:watch": "vitest",
     "test:types": "tsc --project tsconfig.test.json",
-    "pretty": "prettier --write \"{src,test}/**/*.{ts,tsx}\""
+    "pretty": "prettier --write \"{src,test}/**/*.{ts,tsx}\"",
+    "release": "pnpm build && changeset publish"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",


### PR DESCRIPTION
the ci try to run a `pnpm run release`, but that entry wasn't added

https://github.com/solidjs/solid-router/actions/runs/13138191481/job/36658572485