### PR TITLE
fix: createAsync - catch errors of prev to avoid bubbling error up

### DIFF
--- a/test/data.spec.tsx
+++ b/test/data.spec.tsx
@@ -1,0 +1,156 @@
+import {
+  ErrorBoundary,
+  ParentProps,
+  Suspense,
+  catchError,
+  createRoot,
+  createSignal
+} from "solid-js";
+import { render } from "solid-js/web";
+import { createAsync, createAsyncStore } from "../src/data";
+import { awaitPromise, waitFor } from "./helpers";
+
+function Parent(props: ParentProps) {
+  return <ErrorBoundary fallback={<div id="parentError" />}>{props.children}</ErrorBoundary>;
+}
+
+async function getText(arg?: string) {
+  return arg || "fallback";
+}
+async function getError(arg?: any): Promise<any> {
+  throw Error("error");
+}
+
+describe("createAsync should", () => {
+  test("return 'fallback'", () => {
+    createRoot(() => {
+      const data = createAsync(() => getText());
+      setTimeout(() => expect(data()).toBe("fallback"), 1);
+    });
+  });
+  test("return 'text'", () => {
+    createRoot(() => {
+      const data = createAsync(() => getText("text"));
+      setTimeout(() => expect(data()).toBe("text"), 1);
+    });
+  });
+  test("initial error to be caught ", () => {
+    createRoot(() => {
+      const data = createAsync(() => getError());
+      setTimeout(() => catchError(data, err => expect(err).toBeInstanceOf(Error)), 1);
+    });
+  });
+  test("catch error after arg change - initial valid", () =>
+    createRoot(async dispose => {
+      async function throwWhenError(arg: string): Promise<string> {
+        if (arg === "error") throw new Error("error");
+        return arg;
+      }
+
+      const [arg, setArg] = createSignal("");
+      function Child() {
+        const data = createAsync(() => throwWhenError(arg()));
+
+        return (
+          <div id="child">
+            <ErrorBoundary
+              fallback={(_, reset) => (
+                <div id="childError">
+                  <button
+                    id="reset"
+                    onClick={() => {
+                      setArg("true");
+                      reset();
+                    }}
+                  />
+                </div>
+              )}
+            >
+              <Suspense>
+                <p id="data">{data()}</p>
+                <p id="latest">{data.latest}</p>
+              </Suspense>
+            </ErrorBoundary>
+          </div>
+        );
+      }
+      await render(
+        () => (
+          <Parent>
+            <Child />
+          </Parent>
+        ),
+        document.body
+      );
+      const childErrorElement = () => document.getElementById("childError");
+      const parentErrorElement = document.getElementById("parentError");
+      expect(childErrorElement()).toBeNull();
+      expect(parentErrorElement).toBeNull();
+      setArg("error");
+      await awaitPromise();
+
+      // after changing the arg the error should still be caught by the Child's ErrorBoundary
+      expect(childErrorElement()).not.toBeNull();
+      expect(parentErrorElement).toBeNull();
+
+      //reset ErrorBoundary
+      document.getElementById("reset")?.click();
+
+      expect(childErrorElement()).toBeNull();
+      await awaitPromise();
+      const dataEl = () => document.getElementById("data");
+
+      expect(dataEl()).not.toBeNull();
+      expect(document.getElementById("data")?.innerHTML).toBe("true");
+      expect(document.getElementById("latest")?.innerHTML).toBe("true");
+
+      document.body.innerHTML = "";
+      dispose();
+    }));
+  test("catch consecutive error after initial error change to be caught after arg change", () =>
+    createRoot(async cleanup => {
+      const [arg, setArg] = createSignal("error");
+      function Child() {
+        const data = createAsync(() => getError(arg()));
+
+        return (
+          <div id="child">
+            <ErrorBoundary
+              fallback={(_, reset) => (
+                <div id="childError">
+                  <button id="reset" onClick={() => reset()} />
+                </div>
+              )}
+            >
+              <Suspense>{data()}</Suspense>
+            </ErrorBoundary>
+          </div>
+        );
+      }
+      await render(
+        () => (
+          <Parent>
+            <Child />
+          </Parent>
+        ),
+        document.body
+      );
+
+      // Child's ErrorBoundary should catch the error
+      expect(document.getElementById("childError")).not.toBeNull();
+      expect(document.getElementById("parentError")).toBeNull();
+      setArg("error_2");
+      await awaitPromise();
+      // after changing the arg the error should still be caught by the Child's ErrorBoundary
+      expect(document.getElementById("childError")).not.toBeNull();
+      expect(document.getElementById("parentError")).toBeNull();
+
+      document.getElementById("reset")?.click();
+      await awaitPromise();
+      expect(document.getElementById("childError")).not.toBeNull();
+      expect(document.getElementById("parentError")).toBeNull();
+
+      document.body.innerHTML = "";
+      cleanup();
+    }));
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -23,3 +23,7 @@ export function createAsyncRoot(fn: (resolve: () => void, disposer: () => void) 
     createRoot(disposer => fn(resolve, disposer));
   });
 }
+
+export async function awaitPromise() {
+  return new Promise(resolve => setTimeout(resolve, 100));
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,6 @@
     "outDir": "./dist",
     "module": "esnext"
   },
-  "include": [
-    "./src"
-  ],
+  "include": ["./src", "./test"],
   "exclude": ["node_modules/"]
 }


### PR DESCRIPTION
currently when the inner function of createAsync's inner function throws after an arg has updated, the error will not be caught by the closest ErrorBoundary that wraps the accessor. It will bubble up instead. Which is kind of inconsistent, because if there is an initial error it will be caught by the closest ErrorBoundary

wrapping the the prev in catchError and returning undefined instead resolves this.

```ts
[resource] = createResource(
    () =>
      subFetch(
        fn,
        catchError(
          () => untrack(prev),
          () => undefined
        )
      ),
    v => v,
```
Also added tests for a few different simple scenarios of create async.

[Simple reproduction](https://playground.solidjs.com/anonymous/1744fd48-1bb4-49dd-8220-797a0194c40b)