### PR TITLE
chore: Remove unused import from createAsync.ts

### DIFF
--- a/src/data/createAsync.ts
+++ b/src/data/createAsync.ts
@@ -7,7 +7,6 @@
  * and exposes a `.latest` convenience property.
  */
 import { createMemo, latest as solidLatest } from "solid-js";
-import { isServer } from "@solidjs/web";
 
 export type AccessorWithLatest<T> = {
   (): T;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Unused variable of `isServer` was used in `createAsync.ts`
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Remove unused import of `isServer` from `createAsync.ts`.

## Other information
