### PR TITLE
chore(ci): set top-level permissions on workflows

### DIFF
--- a/.github/workflows/dist-typecheck.yml
+++ b/.github/workflows/dist-typecheck.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   typecheck-dist:
     name: Check dist types

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Each of these workflows runs without a top-level `permissions:` block, so its `GITHUB_TOKEN` inherits the repository (or org) default, which is frequently read/write for all scopes.

Setting `contents: read` explicitly on `.github/workflows/dist-typecheck.yml`, `.github/workflows/test.yml` keeps the workflow token scoped to what the job actually uses. If a third-party action or transitive dependency in the run were ever compromised, a read-only token limits the damage (no pushes, no releases, no token-backed writes). The change is mechanical and does not alter any step.