### PR TITLE
Fix bound action registration cleanup

### DIFF
--- a/.changeset/quiet-actions-stay.md
+++ b/.changeset/quiet-actions-stay.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Prevent stale bound action cleanup from unregistering a newer action with the same URL.

--- a/src/data/action.ts
+++ b/src/data/action.ts
@@ -210,7 +210,10 @@ function toAction<T extends Array<any>, U, V = T>(
   fn[invokeSymbol] = invoke;
   if (!isServer) {
     actions.set(url, fn as unknown as Action<T, U, V>);
-    getOwner() && onCleanup(() => actions.delete(url));
+    getOwner() &&
+      onCleanup(() => {
+        if (actions.get(url) === fn) actions.delete(url);
+      });
   }
   return fn as unknown as Action<T, U, V>;
 }

--- a/test/data/action.spec.ts
+++ b/test/data/action.spec.ts
@@ -88,6 +88,31 @@ describe("action", () => {
     expect(actions.get(testAction.url)).toBe(testAction);
   });
 
+  test("should not unregister a replacement action with the same URL", () => {
+    const testAction = action(async (value: string) => value, "replacement-test");
+    let disposeFirst!: () => void;
+    let disposeSecond!: () => void;
+
+    const first = createRoot(dispose => {
+      disposeFirst = dispose;
+      return testAction.with("value");
+    });
+    const second = createRoot(dispose => {
+      disposeSecond = dispose;
+      return testAction.with("value");
+    });
+
+    expect(first.url).toBe(second.url);
+    expect(actions.get(second.url)).toBe(second);
+
+    disposeFirst();
+
+    expect(actions.get(second.url)).toBe(second);
+
+    disposeSecond();
+    expect(actions.has(second.url)).toBe(false);
+  });
+
   test("should support `.with` method for currying arguments", () => {
     const baseAction = action(async (prefix: string, data: string) => {
       return `${prefix}: ${data}`;


### PR DESCRIPTION
## Summary

- preserve a newer bound action registration when an older owner with the same action URL is disposed
- add regression coverage for repeated `.with()` bindings that share a URL
- add a patch changeset

This fixes forms falling through to native submission at `https://action/...` after an optimistic update recreates a bound action.

## Testing

- `pnpm test`
- `pnpm vitest run test/data/action.spec.ts test/data/events.spec.ts`
- `pnpm test:types`