### PR TITLE
Fix duplicate single-flight revalidation

### DIFF
--- a/src/data/action.ts
+++ b/src/data/action.ts
@@ -3,6 +3,7 @@ import { isResponseEnvelope, isServer, type JSX } from "@solidjs/web";
 import {
   createServerReference,
   decodeResponse,
+  isServerFunction,
   subscribeFlightData,
   type SingleFlightPayload
 } from "@solidjs/web/server-functions";
@@ -148,7 +149,7 @@ function createServerFormAction(
     (form: FormData | URLSearchParams) => stub(form) as Promise<unknown>,
     { url }
   );
-  return actionImpl(caller);
+  return actionImpl(caller, {}, true);
 }
 
 /**
@@ -219,7 +220,8 @@ export function useAction<T extends Array<any>, U, V>(action: Action<T, U, V>) {
 
 function actionImpl<T extends Array<any>, U = void>(
   fn: (...args: T) => Promise<U>,
-  options: string | { name?: string } = {}
+  options: string | { name?: string } = {},
+  serverFunction = isServerFunction(fn)
 ): Action<T, U> {
   async function invoke(
     this: { r: RouterContext; f?: HTMLFormElement },
@@ -262,7 +264,12 @@ function actionImpl<T extends Array<any>, U = void>(
             : undefined
         })
       );
-      response = await handleResponse(settled.value, settled.error, router.navigatorFactory());
+      response = await handleResponse(
+        settled.value,
+        settled.error,
+        router.navigatorFactory(),
+        serverFunction && router.singleFlight
+      );
     } finally {
       form && setFormBusy(form, -1);
     }
@@ -430,7 +437,12 @@ async function applyResponseMetadata(
   await revalidate(keys, false);
 }
 
-async function handleResponse(response: unknown, error: boolean | undefined, navigate: Navigator) {
+async function handleResponse(
+  response: unknown,
+  error: boolean | undefined,
+  navigate: Navigator,
+  metadataHandled: boolean
+) {
   let data: any;
   let flightData: Record<string, any> | undefined;
   let metadata: Response | undefined;
@@ -455,6 +467,10 @@ async function handleResponse(response: unknown, error: boolean | undefined, nav
     }
   } else if (error) return { error: response };
   else data = response;
-  await applyResponseMetadata(metadata, navigate, flightData);
+  // The transport consumer applies metadata before returning a server
+  // function's unwrapped value. Do not treat that value as a second plain
+  // action response and invalidate the freshly seeded query cache again.
+  if (!metadataHandled || metadata || flightData)
+    await applyResponseMetadata(metadata, navigate, flightData);
   return data != null ? { data } : undefined;
 }

--- a/test/data/flight-consumer.spec.ts
+++ b/test/data/flight-consumer.spec.ts
@@ -9,6 +9,8 @@ let consumer: FlightDataConsumer<Record<string, any>> | undefined;
 
 vi.mock("@solidjs/web/server-functions", () => ({
   decodeResponse: vi.fn(),
+  isServerFunction: (fn: unknown) =>
+    typeof fn === "function" && !!(fn as any)[Symbol.for("solid.ServerFunctionMetadata")],
   subscribeFlightData: (c: FlightDataConsumer<Record<string, any>>) => {
     consumer = c;
     return () => {
@@ -69,6 +71,52 @@ describe("setupFlightDataConsumer", () => {
       { response: new Response(null, { headers: { "X-Revalidate": "notes" } }) }
     );
     expect(query.get("notes[]")).toEqual(["fresh"]);
+  });
+
+  test("does not revalidate flight data again after a server action settles", async () => {
+    const fetchNotes = vi.fn(async () => ["stale"]);
+    const notes = query(fetchNotes, "notes");
+    await notes();
+
+    (router as any).singleFlight = true;
+    setupFlightDataConsumer(router);
+    const save = async () => {
+      await consumer!(
+        { "notes[]": ["fresh"] },
+        { response: new Response(null, { headers: { "X-Revalidate": "notes" } }) }
+      );
+      return "saved";
+    };
+    (save as any)[Symbol.for("solid.ServerFunctionMetadata")] = {};
+
+    await action(save, "save-notes").call({ r: router });
+
+    expect(await notes()).toEqual(["fresh"]);
+    expect(fetchNotes).toHaveBeenCalledTimes(1);
+  });
+
+  test("continues to revalidate plain client action results", async () => {
+    const fetchNotes = vi.fn(async () => ["notes"]);
+    const notes = query(fetchNotes, "notes");
+    await notes();
+
+    await action(async () => "saved", "save-notes").call({ r: router });
+    await notes();
+
+    expect(fetchNotes).toHaveBeenCalledTimes(2);
+  });
+
+  test("continues to revalidate server actions when single flight is disabled", async () => {
+    const fetchNotes = vi.fn(async () => ["notes"]);
+    const notes = query(fetchNotes, "notes");
+    await notes();
+    const save = async () => "saved";
+    (save as any)[Symbol.for("solid.ServerFunctionMetadata")] = {};
+
+    await action(save, "save-notes").call({ r: router });
+    await notes();
+
+    expect(fetchNotes).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
## Summary

- detect server-function-backed actions, including synthesized server form actions
- skip the action layer metadata pass when the enabled single-flight transport already consumed it
- preserve default revalidation for client actions and for server actions with single flight disabled

## Problem

The single-flight transport consumer applies `X-Revalidate` metadata and seeds the query cache before returning the unwrapped mutation value. The action layer then treated that plain value as a fresh action result and applied default metadata handling again. That second pass invalidated the newly seeded cache and intermittently issued a follow-up query GET.

## Verification

- `pnpm test` (306 client tests, 28 server tests, type tests)
- `pnpm build`
- reproduced in Chrome before the fix as POST + GET; verified five repeated submissions produce only the mutation POST after the fix