### PR TITLE
fix: skip non-http(s) links in anchor click handler

### DIFF
--- a/.changeset/skip-non-http-anchor-links.md
+++ b/.changeset/skip-non-http-anchor-links.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Anchor click handling no longer intercepts links with a non-http(s) scheme (`blob:`, `mailto:`, `tel:`, `data:`, …). Previously `blob:` links could be wrongly routed because they inherit the page origin and bypassed the same-origin check.

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -56,6 +56,9 @@ export function setupNativeEvents({
       if (a.hasAttribute("download") || (rel && rel.includes("external"))) return;
 
       const url = svg ? new URL(href, document.baseURI) : new URL(href);
+      // Skip non-http(s) schemes (blob:, mailto:, tel:, data:, ...). blob: URLs
+      // inherit the page origin, so the origin check below won't reject them. #382
+      if (url.protocol !== "https:" && url.protocol !== "http:") return;
       if (
         url.origin !== window.location.origin ||
         (basePath && url.pathname && !url.pathname.toLowerCase().startsWith(basePath.toLowerCase()))

--- a/test/data/events.spec.ts
+++ b/test/data/events.spec.ts
@@ -184,23 +184,35 @@ describe("anchor link handling", () => {
     } as any;
 
     global.URL = class MockURL {
+      protocol: string;
       origin: string;
       pathname: string;
       search: string;
       hash: string;
 
       constructor(url: string) {
-        if (url.startsWith("/")) {
+        if (url.startsWith("blob:")) {
+          // blob: URLs inherit the page origin, so the origin check alone
+          // would let them through — they must be rejected by protocol. #382
+          this.protocol = "blob:";
+          this.origin = "https://example.com";
+          this.pathname = url;
+          this.search = "";
+          this.hash = "";
+        } else if (url.startsWith("/")) {
+          this.protocol = "https:";
           this.origin = "https://example.com";
           this.pathname = url;
           this.search = "";
           this.hash = "";
         } else if (url.startsWith("https://example.com")) {
+          this.protocol = "https:";
           this.origin = "https://example.com";
           this.pathname = url.replace("https://example.com", "") || "/";
           this.search = "";
           this.hash = "";
         } else {
+          this.protocol = "https:";
           this.origin = "https://other.com";
           this.pathname = "/";
           this.search = "";
@@ -246,6 +258,26 @@ describe("anchor link handling", () => {
       clickHandler(event);
 
       expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  test("should ignore non-http(s) links like blob: (#382)", () => {
+    return createRoot(() => {
+      const navigateFromRoute = vi.fn();
+      mockRouter.navigatorFactory = () => navigateFromRoute;
+      // With no base path, a blob: link shares the page origin and its pathname
+      // isn't caught by the path-prefix check — so it must be rejected by
+      // protocol, else the router routes a garbage pathname (#382).
+      mockRouter.base = { path: () => "" } as any;
+      setupNativeEvents()(mockRouter);
+
+      const link = createMockElement("a", { href: "blob:https://example.com/abc" });
+      const event = createMockEvent("click", link, { path: [link] });
+
+      clickHandler(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(navigateFromRoute).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Fixes #382

## Problem
`handleAnchor` decides whether to intercept an `<a>` click for client-side routing via the same-origin check (`url.origin === window.location.origin`). But **`blob:` URLs inherit the page origin** — `new URL("blob:https://example.com/abc").origin === "https://example.com"` — so they pass that check and get routed to a garbage pathname instead of being left for the browser to handle.

Other non-http(s) schemes (`mailto:`, `tel:`, `data:`, `javascript:`, `file:`, `ws:`/`wss:`) have origin `null` or a non-matching origin, so the existing origin check already rejects them — **only `blob:` slips through.**

## Fix
Guard against any non-http(s) scheme before the origin check:

```ts
const url = svg ? new URL(href, document.baseURI) : new URL(href);
if (url.protocol !== "https:" && url.protocol !== "http:") return;
```

`blob:` links are now skipped (previously routed); every other scheme is unchanged. A general non-http(s) guard is preferred over `blob:`-only — same size, but correct for any scheme that inherits the page origin (e.g. `ws:`/`wss:`).

## Test
Adds a regression test using a no-base-path router (the scenario where a `blob:` link shares the page origin and slips past both the origin and path-prefix checks). Verified it **fails without the guard** (`preventDefault` is called → the blob gets routed) and **passes with it**.

- Full suite: 260 passing
- `tsc` typecheck: clean
- Prettier: clean
- Changeset: `@solidjs/router` patch