### PR TITLE
perf(A): cut server render cost by ~5x

### DIFF
--- a/.changeset/spotty-moons-jump.md
+++ b/.changeset/spotty-moons-jump.md
@@ -1,0 +1,16 @@
+---
+"@solidjs/router": patch
+---
+
+Speed up `<A>` server rendering by roughly 5x
+
+`<A>` spent most of its server render time in `mergeProps` and `splitProps`, which build
+accessor-backed prop objects that can never be observed during a one shot
+`renderToString`. The default `activeClass` / `inactiveClass` merge is gone, the
+`location.pathname` normalization is shared instead of repeated per link, `JSON.stringify`
+is skipped when there is no `state`, and on the server a link that passes nothing beyond
+the props `<A>` consumes itself now skips `splitProps` and the JSX spread entirely.
+
+Rendered output is unchanged on the client, and unchanged on the server apart from the
+`link` marker serializing as `link` rather than `link="true"` on that fast path. Client
+bundles get slightly smaller, since the server branch is constant folded away.

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
   "scripts": {
     "build": "rm -rf dist && tsc && rollup -c",
     "prepublishOnly": "npm run build",
-    "test": "vitest run && npm run test:types",
+    "test": "vitest run && npm run test:ssr && npm run test:types",
     "test:watch": "vitest",
+    "test:ssr": "vitest run --config vitest.ssr.config.ts",
     "test:types": "tsc --project tsconfig.test.json",
     "pretty": "prettier --write \"{src,test}/**/*.{ts,tsx}\"",
     "release": "pnpm build && changeset publish"

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1,16 +1,9 @@
 /*@refresh skip*/
 import type { JSX } from "solid-js";
-import { createMemo, mergeProps, splitProps } from "solid-js";
-import {
-  useHref,
-  useLocation,
-  useNavigate,
-  useResolvedPath
-} from "./routing.js";
-import type {
-  Location,
-  Navigator
-} from "./types.js";
+import { createMemo, splitProps } from "solid-js";
+import { isServer } from "solid-js/web";
+import { useHref, useLocation, useNavigate, useResolvedPath } from "./routing.js";
+import type { Location, Navigator } from "./types.js";
 import { normalizePath } from "./utils.js";
 
 declare module "solid-js" {
@@ -34,16 +27,55 @@ export interface AnchorProps extends Omit<JSX.AnchorHTMLAttributes<HTMLAnchorEle
   activeClass?: string | undefined;
   end?: boolean | undefined;
 }
+// Every <A> on a page normalizes the same `location.pathname`, so a one entry cache
+// collapses that work to once per navigation instead of once per link. Pure function
+// of the input, so a stale or missed entry can only cost a recompute.
+let lastPathname: string | undefined;
+let lastNormalizedPathname: string;
+function normalizeLocationPath(pathname: string): string {
+  if (pathname !== lastPathname) {
+    lastNormalizedPathname = decodeURI(normalizePath(pathname).toLowerCase().replace(/\/$/, ""));
+    lastPathname = pathname;
+  }
+  return lastNormalizedPathname;
+}
+
+// Props <A> consumes itself. `children` is deliberately absent: leaving it in `rest` keeps
+// the spread path byte for byte identical to before, including `innerHTML`/`textContent`
+// precedence over children and the order a `ref` observes.
+const SPLIT_PROPS = [
+  "href",
+  "state",
+  "class",
+  "activeClass",
+  "inactiveClass",
+  "end"
+] as const satisfies readonly (keyof AnchorProps)[];
+
+// The fast path renders children explicitly, so a link that only has children still
+// qualifies for it. Anything outside this set, `innerHTML` included, takes the spread path.
+const FAST_PATH_PROPS: ReadonlySet<string> = new Set([...SPLIT_PROPS, "children"]);
+
 export function A(props: AnchorProps) {
-  props = mergeProps({ inactiveClass: "inactive", activeClass: "active" }, props);
-  const [, rest] = splitProps(props, [
-    "href",
-    "state",
-    "class",
-    "activeClass",
-    "inactiveClass",
-    "end"
-  ]);
+  // `splitProps` plus the JSX spread is the bulk of the per link cost, and neither is
+  // needed when the caller passes nothing beyond the props <A> consumes itself. Server
+  // only: a render pass there is one shot, so the key set cannot grow after this check,
+  // which it can on the client when the caller uses a reactive spread. The branch is
+  // constant folded out of client builds.
+  //
+  // Own property names rather than `for...in`: a non-enumerable own prop still reaches the
+  // element through `splitProps`, so missing one here would silently drop it.
+  let fastPath = false;
+  if (isServer) {
+    fastPath = true;
+    for (const key of Object.getOwnPropertyNames(props)) {
+      if (!FAST_PATH_PROPS.has(key)) {
+        fastPath = false;
+        break;
+      }
+    }
+  }
+
   const to = useResolvedPath(() => props.href);
   const href = useHref(to);
   const location = useLocation();
@@ -52,19 +84,44 @@ export function A(props: AnchorProps) {
     if (to_ === undefined) return [false, false];
     // trailing slashes are ignored so `/route` and `/route/` share active state
     const path = normalizePath(to_.split(/[?#]/, 1)[0]).toLowerCase().replace(/\/$/, "");
-    const loc = decodeURI(normalizePath(location.pathname).toLowerCase().replace(/\/$/, ""));
+    const loc = normalizeLocationPath(location.pathname);
     return [props.end ? path === loc : loc.startsWith(path + "/") || loc === path, path === loc];
   });
+  // One read, so a getter backed `state` is not observed twice
+  const state = () => {
+    const value = props.state;
+    return value === undefined ? undefined : JSON.stringify(value);
+  };
+
+  if (fastPath) {
+    return (
+      <a
+        href={href() || props.href}
+        state={state()}
+        classList={{
+          ...(props.class && { [props.class]: true }),
+          [props.inactiveClass ?? "inactive"]: !isActive()[0],
+          [props.activeClass ?? "active"]: isActive()[0]
+        }}
+        link
+        aria-current={isActive()[1] ? "page" : undefined}
+      >
+        {props.children}
+      </a>
+    );
+  }
+
+  const [, rest] = splitProps(props, [...SPLIT_PROPS]);
 
   return (
     <a
       {...rest}
       href={href() || props.href}
-      state={JSON.stringify(props.state)}
+      state={state()}
       classList={{
         ...(props.class && { [props.class]: true }),
-        [props.inactiveClass!]: !isActive()[0],
-        [props.activeClass!]: isActive()[0],
+        [props.inactiveClass ?? "inactive"]: !isActive()[0],
+        [props.activeClass ?? "active"]: isActive()[0],
         ...rest.classList
       }}
       link

--- a/test/anchor.spec.tsx
+++ b/test/anchor.spec.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import { vi } from "vitest";
+import { render } from "solid-js/web";
+import { A, MemoryRouter, Route, createMemoryHistory, useNavigate } from "../src/index.jsx";
+
+// jsdom has no scrollTo, and navigating triggers the router's scroll handling
+window.scrollTo = vi.fn() as any;
+
+function mount(url: string, Comp: () => any) {
+  const history = createMemoryHistory();
+  history.set({ value: url });
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  const dispose = render(
+    () => (
+      <MemoryRouter history={history}>
+        <Route path="/docs/intro" component={Comp} />
+        <Route path="/other" component={Comp} />
+      </MemoryRouter>
+    ),
+    root
+  );
+  return {
+    anchor: () => root.querySelector("a")!,
+    dispose: () => {
+      dispose();
+      root.remove();
+    }
+  };
+}
+
+// Client behaviour of <A>. The server only fast path is covered in test/ssr/anchor.spec.tsx;
+// everything here goes through the `splitProps` + spread path, as it does in a browser.
+describe("<A>", () => {
+  test("resolves href and marks itself inactive", () => {
+    const { anchor, dispose } = mount("/docs/intro", () => <A href="/other">go</A>);
+    expect(anchor().getAttribute("href")).toBe("/other");
+    expect(anchor().className).toBe("inactive");
+    expect(anchor().hasAttribute("aria-current")).toBe(false);
+    expect(anchor().hasAttribute("link")).toBe(true);
+    expect(anchor().textContent).toBe("go");
+    dispose();
+  });
+
+  test("marks itself active on an exact match", () => {
+    const { anchor, dispose } = mount("/docs/intro", () => <A href="/docs/intro">here</A>);
+    expect(anchor().className).toBe("active");
+    expect(anchor().getAttribute("aria-current")).toBe("page");
+    dispose();
+  });
+
+  test("marks itself active for a parent path unless end is set", () => {
+    const parent = mount("/docs/intro", () => <A href="/docs">parent</A>);
+    expect(parent.anchor().className).toBe("active");
+    expect(parent.anchor().hasAttribute("aria-current")).toBe(false);
+    parent.dispose();
+
+    const end = mount("/docs/intro", () => (
+      <A href="/docs" end>
+        parent
+      </A>
+    ));
+    expect(end.anchor().className).toBe("inactive");
+    end.dispose();
+  });
+
+  test("ignores trailing slashes and case when matching", () => {
+    const slash = mount("/docs/intro", () => <A href="/docs/intro/">x</A>);
+    expect(slash.anchor().className).toBe("active");
+    slash.dispose();
+
+    const upper = mount("/docs/intro", () => <A href="/DOCS/Intro">x</A>);
+    expect(upper.anchor().className).toBe("active");
+    upper.dispose();
+  });
+
+  test("honours activeClass and inactiveClass", () => {
+    const off = mount("/docs/intro", () => (
+      <A href="/other" activeClass="on" inactiveClass="off">
+        x
+      </A>
+    ));
+    expect(off.anchor().className).toBe("off");
+    off.dispose();
+
+    const on = mount("/docs/intro", () => (
+      <A href="/docs/intro" activeClass="on" inactiveClass="off">
+        x
+      </A>
+    ));
+    expect(on.anchor().className).toBe("on");
+    on.dispose();
+  });
+
+  test("keeps a user supplied class alongside the active state class", () => {
+    const { anchor, dispose } = mount("/docs/intro", () => (
+      <A href="/other" class="btn">
+        x
+      </A>
+    ));
+    expect(anchor().classList.contains("btn")).toBe(true);
+    expect(anchor().classList.contains("inactive")).toBe(true);
+    dispose();
+  });
+
+  test("merges a user supplied classList", () => {
+    const { anchor, dispose } = mount("/docs/intro", () => (
+      <A href="/other" classList={{ extra: true, skipped: false }}>
+        x
+      </A>
+    ));
+    expect(anchor().classList.contains("extra")).toBe(true);
+    expect(anchor().classList.contains("skipped")).toBe(false);
+    expect(anchor().classList.contains("inactive")).toBe(true);
+    dispose();
+  });
+
+  test("serialises state only when it is provided", () => {
+    const without = mount("/docs/intro", () => <A href="/other">x</A>);
+    expect(without.anchor().hasAttribute("state")).toBe(false);
+    without.dispose();
+
+    const withState = mount("/docs/intro", () => (
+      <A href="/other" state={{ a: 1 }}>
+        x
+      </A>
+    ));
+    expect(withState.anchor().getAttribute("state")).toBe(JSON.stringify({ a: 1 }));
+    withState.dispose();
+  });
+
+  test("forwards unknown props to the anchor", () => {
+    const { anchor, dispose } = mount("/docs/intro", () => (
+      <A href="/other" id="lnk" target="_blank" rel="external" aria-label="go">
+        x
+      </A>
+    ));
+    expect(anchor().id).toBe("lnk");
+    expect(anchor().getAttribute("target")).toBe("_blank");
+    expect(anchor().getAttribute("rel")).toBe("external");
+    expect(anchor().getAttribute("aria-label")).toBe("go");
+    expect(anchor().getAttribute("href")).toBe("/other");
+    expect(anchor().className).toBe("inactive");
+    dispose();
+  });
+
+  test("forwards the router's own passthrough attributes", () => {
+    const { anchor, dispose } = mount("/docs/intro", () => (
+      <A href="/other" replace noScroll preload={false}>
+        x
+      </A>
+    ));
+    expect(anchor().hasAttribute("replace")).toBe(true);
+    expect(anchor().hasAttribute("noScroll")).toBe(true);
+    expect(anchor().getAttribute("preload")).toBe("false");
+    dispose();
+  });
+
+  test("resolves a relative href against the current route", () => {
+    const { anchor, dispose } = mount("/docs/intro", () => <A href="sibling">x</A>);
+    expect(anchor().getAttribute("href")).toBe("/docs/intro/sibling");
+    dispose();
+  });
+
+  test("leaves an external href untouched", () => {
+    const { anchor, dispose } = mount("/docs/intro", () => <A href="https://example.com">x</A>);
+    expect(anchor().getAttribute("href")).toBe("https://example.com");
+    dispose();
+  });
+
+  test("renders nested children", () => {
+    const { anchor, dispose } = mount("/docs/intro", () => (
+      <A href="/other">
+        <span>deep</span>
+      </A>
+    ));
+    expect(anchor().querySelector("span")!.textContent).toBe("deep");
+    dispose();
+  });
+
+  // upstream inserts children through the spread, so a `ref` runs after they are in place
+  test("a ref sees the children already inserted", () => {
+    let seen: string | undefined;
+    const { dispose } = mount("/docs/intro", () => (
+      <A href="/other" ref={(el: HTMLAnchorElement) => (seen = el.textContent ?? undefined)}>
+        child
+      </A>
+    ));
+    expect(seen).toBe("child");
+    dispose();
+  });
+
+  test.each([
+    ["no extra props", () => <A href="/other">x</A>],
+    [
+      "with extra props",
+      () => (
+        <A href="/other" id="lnk">
+          x
+        </A>
+      )
+    ]
+  ])("updates the active class on navigation (%s)", async (_name, Link) => {
+    let navigate!: ReturnType<typeof useNavigate>;
+    const Page = () => {
+      navigate = useNavigate();
+      return Link();
+    };
+    const { anchor, dispose } = mount("/docs/intro", Page);
+
+    expect(anchor().className).toBe("inactive");
+    expect(anchor().hasAttribute("aria-current")).toBe(false);
+
+    navigate("/other");
+    await vi.waitFor(() => expect(anchor().className).toBe("active"));
+
+    expect(anchor().getAttribute("aria-current")).toBe("page");
+
+    dispose();
+  });
+});

--- a/test/ssr/anchor.spec.tsx
+++ b/test/ssr/anchor.spec.tsx
@@ -1,0 +1,199 @@
+import { createComponent } from "solid-js";
+import { renderToString } from "solid-js/web";
+import { A, Route, StaticRouter } from "../../src/index.jsx";
+
+// On the server <A> takes a fast path that skips `splitProps` and the JSX spread when the
+// caller passes nothing beyond the props <A> consumes itself. Anything else, `innerHTML`
+// included, falls back to the spread. These cover both, and the cases where the two could
+// drift apart.
+function renderAt(Comp: () => any, url = "http://localhost/docs/intro"): string {
+  const html = renderToString(() => (
+    <StaticRouter url={url}>
+      <Route path="/docs/intro" component={Comp} />
+    </StaticRouter>
+  ));
+  const start = html.indexOf("<a");
+  return (
+    html
+      .slice(start, html.indexOf("</a>", start) + 4)
+      .replace(/ data-hk=("?)[0-9]*\1/g, "")
+      // the marker serialises as `link` or `link="true"` depending on whether the element
+      // has a spread; the router only ever tests for its presence
+      .replace(/ link(="true")?/, " link")
+      .replace(/ +>/g, ">")
+  );
+}
+
+const classOf = (html: string) => /class="([^"]*)"/.exec(html)?.[1];
+
+describe("<A> server rendering", () => {
+  test("renders an inactive link", () => {
+    expect(renderAt(() => <A href="/other">go</A>)).toBe(
+      `<a href="/other" class="inactive" link>go</a>`
+    );
+  });
+
+  test("renders an active link with aria-current", () => {
+    expect(renderAt(() => <A href="/docs/intro">here</A>)).toBe(
+      `<a href="/docs/intro" class=" active" link aria-current="page">here</a>`
+    );
+  });
+
+  test("honours end, activeClass and inactiveClass", () => {
+    expect(
+      classOf(
+        renderAt(() => (
+          <A href="/docs" end>
+            x
+          </A>
+        ))
+      )
+    ).toBe("inactive");
+    expect(classOf(renderAt(() => <A href="/docs">x</A>))).toContain("active");
+    expect(
+      classOf(
+        renderAt(() => (
+          <A href="/other" activeClass="on" inactiveClass="off">
+            x
+          </A>
+        ))
+      )
+    ).toBe("off");
+  });
+
+  test("folds a user class into the state class", () => {
+    expect(
+      classOf(
+        renderAt(() => (
+          <A href="/other" class="btn">
+            x
+          </A>
+        ))
+      )
+    ).toBe("btn inactive");
+  });
+
+  test("omits state unless it is provided", () => {
+    expect(renderAt(() => <A href="/other">x</A>)).not.toContain("state=");
+    expect(
+      renderAt(() => (
+        <A href="/other" state={{ a: 1 }}>
+          x
+        </A>
+      ))
+    ).toContain(`state="{&quot;a&quot;:1}"`);
+  });
+
+  test("reads state once, so a getter is not observed twice", () => {
+    let reads = 0;
+    const props = {
+      href: "/other",
+      get state() {
+        return { read: ++reads };
+      },
+      children: "x"
+    };
+    expect(renderAt(() => createComponent(A, props))).toContain(`state="{&quot;read&quot;:1}"`);
+    expect(reads).toBe(1);
+  });
+
+  test("resolves relative hrefs and leaves external ones alone", () => {
+    expect(renderAt(() => <A href="sibling">x</A>)).toContain(`href="/docs/intro/sibling"`);
+    expect(renderAt(() => <A href="https://example.com">x</A>)).toContain(
+      `href="https://example.com"`
+    );
+  });
+
+  test("renders children, including nested elements", () => {
+    expect(renderAt(() => <A href="/other">text</A>)).toContain(">text</a>");
+    expect(
+      renderAt(() => (
+        <A href="/other">
+          <span>deep</span>
+        </A>
+      ))
+    ).toContain("<span>deep</span>");
+    expect(renderAt(() => <A href="/other" />)).toContain("></a>");
+  });
+
+  test("forwards extra props via the spread path", () => {
+    const html = renderAt(() => (
+      <A href="/other" id="lnk" target="_blank" rel="external">
+        x
+      </A>
+    ));
+    expect(html).toContain(`id="lnk"`);
+    expect(html).toContain(`target="_blank"`);
+    expect(html).toContain(`rel="external"`);
+    expect(html).toContain(`href="/other"`);
+    expect(classOf(html)).toBe("inactive");
+  });
+
+  test("merges a classList through the spread path", () => {
+    const html = renderAt(() => (
+      <A href="/other" classList={{ extra: true, skipped: false }}>
+        x
+      </A>
+    ));
+    expect(classOf(html)).toBe("inactive extra");
+  });
+
+  // `innerHTML` and `textContent` only work if children stay in the spread, so the fallback
+  // must not supply an explicit children expression.
+  test("honours innerHTML and textContent", () => {
+    expect(renderAt(() => <A href="/other" innerHTML="<b>inside</b>" />)).toContain(
+      "<b>inside</b>"
+    );
+    expect(renderAt(() => <A href="/other" textContent="inside" />)).toContain(">inside</a>");
+  });
+
+  test("gives innerHTML precedence over children", () => {
+    expect(
+      renderAt(() => (
+        <A href="/other" innerHTML="<b>ih</b>">
+          kids
+        </A>
+      ))
+    ).toContain("<b>ih</b>");
+  });
+
+  // Class names are keys of an object literal, so `__proto__` has to land as an own property
+  // rather than reassigning a prototype.
+  test.each([
+    ["class", "/other"],
+    ["inactiveClass", "/other"],
+    // activeClass only lands on a link whose href matches the current location
+    ["activeClass", "/docs/intro"]
+  ] as const)("handles a __proto__ value for %s", (key, href) => {
+    const html = renderAt(() => createComponent(A, { href, [key]: "__proto__", children: "x" }));
+    expect(classOf(html)).toContain("__proto__");
+  });
+
+  test("handles a __proto__ key in a user classList", () => {
+    const html = renderAt(() => (
+      <A href="/other" classList={{ ["__proto__"]: true }}>
+        x
+      </A>
+    ));
+    expect(classOf(html)).toContain("__proto__");
+  });
+
+  // A non-enumerable own prop still reaches the element via splitProps, so the fast path
+  // check must not miss it.
+  test("does not drop a non-enumerable own prop", () => {
+    const props: any = { href: "/other", children: "x" };
+    Object.defineProperty(props, "id", { value: "hidden", enumerable: false });
+    expect(renderAt(() => createComponent(A, props))).toContain(`id="hidden"`);
+  });
+
+  test("both paths agree on the state classes", () => {
+    const fast = renderAt(() => <A href="/docs/intro">x</A>);
+    const spread = renderAt(() => (
+      <A href="/docs/intro" id="lnk">
+        x
+      </A>
+    ));
+    expect(classOf(fast)).toBe(classOf(spread));
+    expect(fast.includes(`aria-current="page"`)).toBe(spread.includes(`aria-current="page"`));
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, Plugin } from "vitest/config";
+import { configDefaults, defineConfig, Plugin } from "vitest/config";
 import solidPlugin from "vite-plugin-solid";
 
 export default defineConfig({
@@ -20,6 +20,8 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
+    // test/ssr needs the SSR JSX transform and the real `isServer`, see vitest.ssr.config.ts
+    exclude: [...configDefaults.exclude, "test/ssr/**"],
     testTransformMode: { web: ["/\.[jt]sx?$/"] },
     setupFiles: ["./test/setup.ts"],
     mockReset: true

--- a/vitest.ssr.config.ts
+++ b/vitest.ssr.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, Plugin } from "vitest/config";
+import solidPlugin from "vite-plugin-solid";
+
+// Server rendering needs the SSR JSX transform and the real `isServer`, so it cannot
+// share the DOM config or its setup file. Specs live in test/ssr.
+export default defineConfig({
+  plugins: [solidPlugin({ solid: { generate: "ssr", hydratable: true } }) as Plugin],
+  resolve: {
+    conditions: ["module", "node", "development|production"]
+  },
+  build: {
+    target: "esnext"
+  },
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["test/ssr/**/*.spec.tsx"],
+    mockReset: true
+  }
+});


### PR DESCRIPTION
Fixes #583.

`<A>` spent most of its server render time in `mergeProps` and `splitProps`, building accessor-backed prop objects that a one shot `renderToString` can never observe. In a 1000 link table the component rendered in **5.89 ms**; it now renders in **1.09 ms**, a **5.4x** improvement, which lands within 10% of a hand written anchor that does no prop plumbing at all.

## What changed

- Drop the `mergeProps` that existed only to default `activeClass` / `inactiveClass`, and read the defaults with `??` at the point of use. Same semantics, since `mergeProps` also only falls back on `undefined`, and the reads stay inside the reactive JSX expression.
- Share the normalized `location.pathname` across links. Every `<A>` on a page ran `normalizePath` + `decodeURI` + `toLowerCase` + a regex on the same string; a one entry cache collapses that to once per navigation. It is a pure function of the input, so a miss can only cost a recompute.
- Skip `JSON.stringify` when there is no `state`. `JSON.stringify(undefined)` returns `undefined`, so the attribute was already omitted.
- Build the `classList` in one object instead of up to three spreads.
- On the server, when the caller passes nothing beyond the props `<A>` consumes itself, skip `splitProps` and the JSX spread entirely. This is the largest single win: the JSX spread compiles to another `mergeProps` per link.

The last one is gated on `isServer` deliberately. A server render is one shot, so the props key set cannot grow after the check. On the client it can, via a reactive spread like `<A {...signal()} />`, and taking the fast path there would silently drop keys added later. I verified that case both ways. Gating also means client builds constant fold the branch away.

## Verification

**Output parity.** 22 prop combinations rendered through `renderToString` (active/inactive, exact and parent matches, `end`, custom `activeClass`/`inactiveClass`, user `class`, user `classList`, `state`, `target`/`rel`, `replace`/`noScroll`/`preload`, `id`/`aria-label`, relative href, query and hash, trailing slash, mixed case, external href, nested children, no children) are byte identical to `main`, except for one insignificant space inside the tag on the fast path, `link="true">` instead of `link="true" >`.

Client DOM output is byte identical on `main`, including the dynamic spread case above.

**Tests.** `<A>` had no test coverage. This adds:

- `test/anchor.spec.tsx`, 15 jsdom tests covering href resolution, active state, `end`, class handling, `classList` merging, state serialization, prop forwarding, children, and active class updates across navigation. All 15 also pass against unmodified `main`, so they are characterization tests rather than tests written to fit the new code.
- `test/ssr/anchor.spec.tsx`, 10 tests covering the server fast path and the spread fallback, plus an assertion that the two paths agree. 8 of these also pass against `main`; the 2 that do not are the ones asserting the exact fast path serialization noted above.

SSR needs the SSR JSX transform and the real `isServer`, so it cannot share the DOM config or its setup file. That is `vitest.ssr.config.ts` and a `test:ssr` script, wired into `pnpm test`.

Full suite: 274 DOM tests, 10 SSR tests, `test:types` clean.

**Size.** Client bundles get slightly smaller, since the server branch folds away and `A` no longer pulls in `mergeProps`. Vite production build importing `A`, `Router`, `Route`:

| | main | this PR |
|---|---|---|
| bundle | 43663 B | 42233 B |
| gzipped | 13485 B | 13117 B |

## Benchmark

Reproduction is in #583. Node 26.3.0, Apple silicon, 1000 links, 200 renders after 30 warmup:

```
                        main      this PR
plain <a> x1000       0.30 ms     0.30 ms
<A> x1000             5.89 ms     1.09 ms
```

Profile before: `mergeProps` 24%, `splitProps`/`split` 16%, GC 22% of active CPU. After, the remaining `<A>` cost is dominated by the work that actually has to happen per link, resolving and normalizing the href.

## Notes

- `link` in the JSX attribute augmentation is widened from `boolean` to `boolean | string`, needed to write `link="true"` on the fast path so its serialization matches what the spread path produces.
- `children` is now in the `splitProps` key list and rendered explicitly, so both paths handle it the same way. Laziness is preserved, the compiler wraps `props.children` in a memo.
