### PR TITLE
Update solid to 2.0.0-rc.1 and adapt fileRoutes to the new lazy() signature

### DIFF
--- a/.changeset/update-solid-rc-1.md
+++ b/.changeset/update-solid-rc-1.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Update `solid-js` / `@solidjs/web` to `2.0.0-rc.1` and raise the peer ranges to `^2.0.0-rc.1`. rc.1 moves `lazy()`'s `moduleUrl` to the third argument (`lazy(fn, options?, moduleUrl?)`), and `fileRoutes` now passes each entry's `src` there — on rc.0 that argument would be silently dropped, so the peer floor rides along.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@solidjs/vite-plugin": "3.0.0-next.28",
-    "@solidjs/web": "^2.0.0-rc.0",
+    "@solidjs/web": "^2.0.0-rc.1",
     "@babel/core": "^7.26.0",
     "@babel/preset-typescript": "^7.26.0",
     "@changesets/cli": "^2.27.10",
@@ -51,18 +51,18 @@
     "@rollup/plugin-terser": "0.4.4",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.0",
-    "babel-preset-solid": "^2.0.0-rc.0",
+    "babel-preset-solid": "^2.0.0-rc.1",
     "jsdom": "^25.0.1",
     "prettier": "^3.4.1",
     "rollup": "^4.27.4",
-    "solid-js": "^2.0.0-rc.0",
+    "solid-js": "^2.0.0-rc.1",
     "typescript": "^5.7.2",
     "vite": "^6.0.0",
     "vitest": "^2.1.6"
   },
   "peerDependencies": {
-    "@solidjs/web": "^2.0.0-rc.0",
-    "solid-js": "^2.0.0-rc.0"
+    "@solidjs/web": "^2.0.0-rc.1",
+    "solid-js": "^2.0.0-rc.1"
   },
   "packageManager": "pnpm@10.19.0+sha512.c9fc7236e92adf5c8af42fd5bf1612df99c2ceb62f27047032f4720b33f8eacdde311865e91c411f2774f618d82f320808ecb51718bfa82c060c4ba7c76a32b8"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,10 +28,10 @@ importers:
         version: 0.4.4(rollup@4.27.4)
       '@solidjs/vite-plugin':
         specifier: 3.0.0-next.28
-        version: 3.0.0-next.28(@solidjs/web@2.0.0-rc.0(solid-js@2.0.0-rc.0))(solid-js@2.0.0-rc.0)(vite@6.0.0(@types/node@22.10.0)(terser@5.36.0))
+        version: 3.0.0-next.28(@solidjs/web@2.0.0-rc.1(solid-js@2.0.0-rc.1))(solid-js@2.0.0-rc.1)(vite@6.0.0(@types/node@22.10.0)(terser@5.36.0))
       '@solidjs/web':
-        specifier: ^2.0.0-rc.0
-        version: 2.0.0-rc.0(solid-js@2.0.0-rc.0)
+        specifier: ^2.0.0-rc.1
+        version: 2.0.0-rc.1(solid-js@2.0.0-rc.1)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -39,8 +39,8 @@ importers:
         specifier: ^22.10.0
         version: 22.10.0
       babel-preset-solid:
-        specifier: ^2.0.0-rc.0
-        version: 2.0.0-rc.0(@babel/core@7.26.0)(solid-js@2.0.0-rc.0)
+        specifier: ^2.0.0-rc.1
+        version: 2.0.0-rc.1(@babel/core@7.26.0)(solid-js@2.0.0-rc.1)
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -51,8 +51,8 @@ importers:
         specifier: ^4.27.4
         version: 4.27.4
       solid-js:
-        specifier: ^2.0.0-rc.0
-        version: 2.0.0-rc.0
+        specifier: ^2.0.0-rc.1
+        version: 2.0.0-rc.1
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -294,8 +294,8 @@ packages:
   '@changesets/write@0.3.2':
     resolution: {integrity: sha512-kDxDrPNpUgsjDbWBvUo27PzKX4gqeKOlhibaOXDJA6kuBisGqNHv/HwGJrAu8U/dSf8ZEFIeHIPtvSlZI1kULw==}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42':
-    resolution: {integrity: sha512-ol24x9RW8loPyOTzC/mQzh/zAsrsPxyTG4WRxxRlwzNK2uBWIBftWN5IwmSV51zDQa7JcT6sE6kkXFCLUvsYIQ==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.43':
+    resolution: {integrity: sha512-JMMS/WHcptu2xMQQhUd7P0c0g2RSvvILg5Fj2y48AiWbPylQX8oXvekDTTXOlrebg1qapqMcEnw0OwYxwr7wOw==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
@@ -848,8 +848,8 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
-  '@solidjs/signals@2.0.0-rc.0':
-    resolution: {integrity: sha512-oKZSfvsCcKw1uJjOGbUkJ+OqlhXLHtZ+rShSyu9KH0lUH7UUwfMfsKeh81JPiQxDDg4YLhEwI38hg0JkwzTdvA==}
+  '@solidjs/signals@2.0.0-rc.1':
+    resolution: {integrity: sha512-KQpgUbn9xuzFaXupwej9MvUnQV+H6wcCgvrERf+dygco3T9JWP9S02g/UoYwwmJ6Vh+LE1b82ZlSHYR2Bd1O8A==}
 
   '@solidjs/vite-plugin@3.0.0-next.28':
     resolution: {integrity: sha512-P/Xova2R8QoveQ2szrzkHSMPZjIyc5dE4hh2UHNgRW8CC5sSoh8yzPLw7qwvKdE1DydPHUWq/hrRIApkwt+grw==}
@@ -862,10 +862,10 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  '@solidjs/web@2.0.0-rc.0':
-    resolution: {integrity: sha512-pYSaA9+dH8H1h/d/ZF/P2kR6omfzFGNcdzKhWTcg9fJghXhn8+5UrXUr2iYxDdYNOXZzxxFQhYHSJ7P4HKDqgw==}
+  '@solidjs/web@2.0.0-rc.1':
+    resolution: {integrity: sha512-wLuxGtQUxaFfqxqhIUJGGSZB/upd3GzokQRFJKvO7biJGNZLAws+eanMqi0kK2Amg+MZZ7aVyPPKydf8mzdhkg==}
     peerDependencies:
-      solid-js: ^2.0.0-rc.0
+      solid-js: ^2.0.0-rc.1
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -991,11 +991,11 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  babel-preset-solid@2.0.0-rc.0:
-    resolution: {integrity: sha512-Ap2/QQY3pICj+Q0VM/RnIOpZo7e6icZnUA0oBJuhqzoCrljqMNo3eFb2OeEa4pUQeFREJOlex4Bt1ggwrcgC8w==}
+  babel-preset-solid@2.0.0-rc.1:
+    resolution: {integrity: sha512-HMefWI9rhIGYmefNCmcX21p7di4UUeuayQceUG1Xi6l0/AEhqi6iqPKMr+vvqP31EkoJU9/EcjIBnqS5vSEEhw==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-rc.0
+      solid-js: ^2.0.0-rc.1
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -1592,8 +1592,8 @@ packages:
   smob@1.4.1:
     resolution: {integrity: sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ==}
 
-  solid-js@2.0.0-rc.0:
-    resolution: {integrity: sha512-3enTJ71VL69nM5p/it2InVBDBt316Cqfij+F0S7VuHZLITc8YV7Rvavjoy52nAKKxYWXM+BcXh2K7KcLTf1zdQ==}
+  solid-js@2.0.0-rc.1:
+    resolution: {integrity: sha512-UD+UfqfiuuOTaDw01YeT+LwsYJC2ilTlMfs6h8EC8FFLmZD0ZjeZIoJXdZEo9uMzIof2tu0Rfh3dnzI7FAmuJQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2261,7 +2261,7 @@ snapshots:
       human-id: 1.0.2
       prettier: 2.8.8
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.42(@babel/core@7.26.0)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.43(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-module-imports': 7.18.6
@@ -2667,28 +2667,28 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-  '@solidjs/signals@2.0.0-rc.0': {}
+  '@solidjs/signals@2.0.0-rc.1': {}
 
-  '@solidjs/vite-plugin@3.0.0-next.28(@solidjs/web@2.0.0-rc.0(solid-js@2.0.0-rc.0))(solid-js@2.0.0-rc.0)(vite@6.0.0(@types/node@22.10.0)(terser@5.36.0))':
+  '@solidjs/vite-plugin@3.0.0-next.28(@solidjs/web@2.0.0-rc.1(solid-js@2.0.0-rc.1))(solid-js@2.0.0-rc.1)(vite@6.0.0(@types/node@22.10.0)(terser@5.36.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.26.0
       '@dom-expressions/compiler': 0.50.0-next.40
-      '@solidjs/web': 2.0.0-rc.0(solid-js@2.0.0-rc.0)
+      '@solidjs/web': 2.0.0-rc.1(solid-js@2.0.0-rc.1)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-rc.0(@babel/core@7.26.0)(solid-js@2.0.0-rc.0)
+      babel-preset-solid: 2.0.0-rc.1(@babel/core@7.26.0)(solid-js@2.0.0-rc.1)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-rc.0
+      solid-js: 2.0.0-rc.1
       vite: 6.0.0(@types/node@22.10.0)(terser@5.36.0)
       vitefu: 1.0.4(vite@6.0.0(@types/node@22.10.0)(terser@5.36.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@solidjs/web@2.0.0-rc.0(solid-js@2.0.0-rc.0)':
+  '@solidjs/web@2.0.0-rc.1(solid-js@2.0.0-rc.1)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.0
+      solid-js: 2.0.0-rc.1
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -2822,12 +2822,12 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  babel-preset-solid@2.0.0-rc.0(@babel/core@7.26.0)(solid-js@2.0.0-rc.0):
+  babel-preset-solid@2.0.0-rc.1(@babel/core@7.26.0)(solid-js@2.0.0-rc.1):
     dependencies:
       '@babel/core': 7.26.0
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.42(@babel/core@7.26.0)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.43(@babel/core@7.26.0)
     optionalDependencies:
-      solid-js: 2.0.0-rc.0
+      solid-js: 2.0.0-rc.1
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -3429,9 +3429,9 @@ snapshots:
 
   smob@1.4.1: {}
 
-  solid-js@2.0.0-rc.0:
+  solid-js@2.0.0-rc.1:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.0
+      '@solidjs/signals': 2.0.0-rc.1
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -154,7 +154,11 @@ export function fileRoutes<const T extends readonly FileRouteEntry[]>(
     }
     let component = components.get(ref.src);
     if (!component) {
-      component = lazy(ref.import as () => Promise<{ default: RouteSectionComponent }>, ref.src);
+      component = lazy(
+        ref.import as () => Promise<{ default: RouteSectionComponent }>,
+        undefined,
+        ref.src
+      );
       components.set(ref.src, component);
     }
     return component;


### PR DESCRIPTION
## Summary

- Bump `solid-js` / `@solidjs/web` / `babel-preset-solid` devDependencies to `^2.0.0-rc.1` and raise the peer ranges to `^2.0.0-rc.1`.
- Adapt `fileRoutes` to rc.1's new `lazy()` signature: `moduleUrl` moved from the second argument to the third (`lazy(fn, options?, moduleUrl?)`), so the code-split branch now calls `lazy(ref.import, undefined, ref.src)`.

The peer floor bump is required, not cosmetic: on rc.0, `lazy()` takes `moduleUrl` second, so the adapted call would silently drop it — losing the URL that SSR resolves client assets against. Conversely, rc.1's dev build throws on the old string-second-argument call.

## Verification

- Full suite green on rc.1: 348 client tests, 28 server tests, type checks, build.
- Reproduced the breakage end-to-end in a fullstack SSR test app pinned to solid 2.0.0-rc.1 with the published `@solidjs/router@2.0.0-next.16`: production SSR logs `lazy() used in SSR without a moduleUrl … the component will load late during hydration` and the route chunks are absent from the SSR HTML.
- With this branch linked in, the warning is gone, the SSR HTML preloads the route chunks (`index-*.js`, `users-*.js`), both `/` and `/users/1` render, and hydration works (event replay + counter interactivity verified in the browser).

Patch changeset included, following the rc.0 bump convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)