### PR TITLE
Track the server-function data address

### DIFF
--- a/.changeset/expect-server-function-data-address.md
+++ b/.changeset/expect-server-function-data-address.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Track the server-function data address (solidjs/solid#3094). Scripted calls now go to `<endpoint>/data/<id>` while rendered action urls stay at the bare `<endpoint>/<id>`; the router needed no functional change — synthesized form actions already hand the rendered url to `createServerReference`, and the transport re-addresses its own calls — so this updates the wire-shape expectations in tests and the synthesis doc comment. Requires the @solidjs/web release that carries the data-address split.

--- a/.changeset/expect-server-function-data-address.md
+++ b/.changeset/expect-server-function-data-address.md
@@ -2,4 +2,4 @@
 "@solidjs/router": patch
 ---
 
-Track the server-function data address (solidjs/solid#3094). Scripted calls now go to `<endpoint>/data/<id>` while rendered action urls stay at the bare `<endpoint>/<id>`; the router needed no functional change — synthesized form actions already hand the rendered url to `createServerReference`, and the transport re-addresses its own calls — so this updates the wire-shape expectations in tests and the synthesis doc comment. Requires the @solidjs/web release that carries the data-address split.
+Track the server-function data address (solidjs/solid#3094). Scripted calls now go to `<endpoint>/data/<id>` while rendered action urls stay at the bare `<endpoint>/<id>`; the router needed no functional change — synthesized form actions already hand the rendered url to `createServerReference`, and the transport re-addresses its own calls — so this updates the wire-shape expectations in tests and the synthesis doc comment. Requires `@solidjs/web` 2.0.0-rc.5 (the release carrying the data-address split); the peer floor is raised to `^2.0.0-rc.5`.

--- a/.changeset/redirect-carrier-semantics.md
+++ b/.changeset/redirect-carrier-semantics.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/router": patch
+---
+
+Navigate from the redirect carrier instead of sniffing Location. Server-function redirects now arrive as `X-Server-Function-Redirect: <status> <resolved-url>` (solidjs/solid#3102), so the soft/hard split is a real origin comparison — same-origin targets navigate softly with `replace: true` (the target takes the submission's place in history, matching HTTP's form-post semantics), anything else hard-navigates — never a guess from how the author spelled the target, which sent relative and absolute spellings down different navigation paths (solidjs/solid#3107). A locally-produced `redirect()` (a client-side action) still navigates from its real 3xx + Location; a `Location` on any other status is the author's data and never navigates.

--- a/package.json
+++ b/package.json
@@ -48,21 +48,21 @@
     "@rollup/plugin-node-resolve": "15.3.0",
     "@rollup/plugin-terser": "0.4.4",
     "@solidjs/vite-plugin": "3.0.0-next.35",
-    "@solidjs/web": "^2.0.0-rc.4",
+    "@solidjs/web": "^2.0.0-rc.5",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.0",
     "babel-preset-solid": "^2.0.0-rc.2",
     "jsdom": "^25.0.1",
     "prettier": "^3.4.1",
     "rollup": "^4.27.4",
-    "solid-js": "^2.0.0-rc.4",
+    "solid-js": "^2.0.0-rc.5",
     "typescript": "^5.7.2",
     "vite": "^8.2.2",
     "vitest": "^4.1.11"
   },
   "peerDependencies": {
-    "@solidjs/web": "^2.0.0-rc.4",
-    "solid-js": "^2.0.0-rc.4"
+    "@solidjs/web": "^2.0.0-rc.5",
+    "solid-js": "^2.0.0-rc.5"
   },
   "packageManager": "pnpm@10.19.0+sha512.c9fc7236e92adf5c8af42fd5bf1612df99c2ceb62f27047032f4720b33f8eacdde311865e91c411f2774f618d82f320808ecb51718bfa82c060c4ba7c76a32b8"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,10 +28,10 @@ importers:
         version: 0.4.4(rollup@4.27.4)
       '@solidjs/vite-plugin':
         specifier: 3.0.0-next.35
-        version: 3.0.0-next.35(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(solid-js@2.0.0-rc.4)(vite@8.2.2(@types/node@22.10.0)(terser@5.36.0))
+        version: 3.0.0-next.35(@solidjs/web@2.0.0-rc.5(solid-js@2.0.0-rc.5))(solid-js@2.0.0-rc.5)(vite@8.2.2(@types/node@22.10.0)(terser@5.36.0))
       '@solidjs/web':
-        specifier: ^2.0.0-rc.4
-        version: 2.0.0-rc.4(solid-js@2.0.0-rc.4)
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -40,7 +40,7 @@ importers:
         version: 22.10.0
       babel-preset-solid:
         specifier: ^2.0.0-rc.2
-        version: 2.0.0-rc.2(@babel/core@7.26.0)(solid-js@2.0.0-rc.4)
+        version: 2.0.0-rc.2(@babel/core@7.26.0)(solid-js@2.0.0-rc.5)
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -51,8 +51,8 @@ importers:
         specifier: ^4.27.4
         version: 4.27.4
       solid-js:
-        specifier: ^2.0.0-rc.4
-        version: 2.0.0-rc.4
+        specifier: ^2.0.0-rc.5
+        version: 2.0.0-rc.5
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -680,8 +680,8 @@ packages:
   '@solidjs/compiler@2.0.0-rc.4':
     resolution: {integrity: sha512-lKx6Jp1KbHxqO+v+g7cRbm8I1DHx/10Lj8bKG4vmdGnCfSlFbyhCd8cPTLdLV0YVG7GGSzzF5m8NkC9NlfGN5w==}
 
-  '@solidjs/signals@2.0.0-rc.4':
-    resolution: {integrity: sha512-l7P0g8+2pnNscaIPOGDMhv0boaidGAsvR8QN66JySIWNMvVnuq2ayv7ZnvP+IR00DJC+RqCNnnTG/UCdxf+h8g==}
+  '@solidjs/signals@2.0.0-rc.5':
+    resolution: {integrity: sha512-Ks+97LbyN2vYqPEHWpy2YY+MYgoSCge0kHOUFN/Bzdz1Ex/M9Is1HIyBZGBVhf5y35394List5WWlU44yEnm4w==}
 
   '@solidjs/vite-plugin@3.0.0-next.35':
     resolution: {integrity: sha512-8Mlftd+WfZkwOoCZRyMxA8innT8b2D/qawTu+28RW/Hj4eSmStSLx4dHjYeH9MxyOwo7DQStAyHAADk5LFQVRw==}
@@ -698,10 +698,10 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  '@solidjs/web@2.0.0-rc.4':
-    resolution: {integrity: sha512-acM9W0FByf0aJDMG5kMbHr0BLTjvFIg8lxwLwHzsu3ybWSmsP1FiOOs2RHNItve/AiX+MGR9CQBCazmnfPykEA==}
+  '@solidjs/web@2.0.0-rc.5':
+    resolution: {integrity: sha512-0Q9QNJXgXDTl4dH8Nr972XdL3ET+GBV/UlxhBG1ZV7U54/PP2yhTJggWxubJNqfeWel8p/W8laNgtS3nLiZpbw==}
     peerDependencies:
-      solid-js: ^2.0.0-rc.4
+      solid-js: ^2.0.0-rc.5
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1504,8 +1504,8 @@ packages:
   smob@1.4.1:
     resolution: {integrity: sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ==}
 
-  solid-js@2.0.0-rc.4:
-    resolution: {integrity: sha512-hSkDmtduesjFtvzjNyqLphrqiSvhSD5+njkPQUR+9YEoR60MMWtuv36SbLL4OucI0Ronof3Jc+AsUp0oWffwMg==}
+  solid-js@2.0.0-rc.5:
+    resolution: {integrity: sha512-AI9ndOlUtXXeFf0/MUADM5HfMYwXtxfitIayOkjBCZl67ZyD4ct5+4kqv0EF2xeyIrUwlsrFTuKpHs54BNA6iw==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2486,28 +2486,28 @@ snapshots:
       '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.4
       '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.4
 
-  '@solidjs/signals@2.0.0-rc.4': {}
+  '@solidjs/signals@2.0.0-rc.5': {}
 
-  '@solidjs/vite-plugin@3.0.0-next.35(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(solid-js@2.0.0-rc.4)(vite@8.2.2(@types/node@22.10.0)(terser@5.36.0))':
+  '@solidjs/vite-plugin@3.0.0-next.35(@solidjs/web@2.0.0-rc.5(solid-js@2.0.0-rc.5))(solid-js@2.0.0-rc.5)(vite@8.2.2(@types/node@22.10.0)(terser@5.36.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.26.0
       '@solidjs/babel-plugin': 2.0.0-rc.4(@babel/core@7.26.0)
       '@solidjs/compiler': 2.0.0-rc.4
-      '@solidjs/web': 2.0.0-rc.4(solid-js@2.0.0-rc.4)
+      '@solidjs/web': 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       '@types/babel__core': 7.20.5
       merge-anything: 5.1.7
-      solid-js: 2.0.0-rc.4
+      solid-js: 2.0.0-rc.5
       vite: 8.2.2(@types/node@22.10.0)(terser@5.36.0)
       vitefu: 1.0.4(vite@8.2.2(@types/node@22.10.0)(terser@5.36.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4)':
+  '@solidjs/web@2.0.0-rc.5(solid-js@2.0.0-rc.5)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.4
+      solid-js: 2.0.0-rc.5
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2651,12 +2651,12 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  babel-preset-solid@2.0.0-rc.2(@babel/core@7.26.0)(solid-js@2.0.0-rc.4):
+  babel-preset-solid@2.0.0-rc.2(@babel/core@7.26.0)(solid-js@2.0.0-rc.5):
     dependencies:
       '@babel/core': 7.26.0
       '@dom-expressions/babel-plugin-jsx': 0.50.0-next.44(@babel/core@7.26.0)
     optionalDependencies:
-      solid-js: 2.0.0-rc.4
+      solid-js: 2.0.0-rc.5
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -3267,9 +3267,9 @@ snapshots:
 
   smob@1.4.1: {}
 
-  solid-js@2.0.0-rc.4:
+  solid-js@2.0.0-rc.5:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.4
+      '@solidjs/signals': 2.0.0-rc.5
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)

--- a/src/data/action.ts
+++ b/src/data/action.ts
@@ -128,11 +128,13 @@ export function handleFormAction(evt: SubmitEvent, router: RouterContext, action
  * carries everything an invocation needs — the function id in the path
  * (`<endpoint>/<id>`) and any bound `.with()` arguments (plain JSON in
  * `?args`, which the server prepends for natural-encoding bodies exactly as
- * it does for no-JS posts) — so the FormData is posted to it verbatim
- * through the server-function transport:
- * submissions, `aria-busy`, redirects, revalidation, and single-flight all
- * flow through the normal action machinery. Registered under the url, so
- * repeat submits reuse it (and a later real registration overrides it).
+ * it does for no-JS posts) — so the FormData is posted through the
+ * server-function transport, which addresses its own scripted calls at the
+ * url's data sibling (`<endpoint>/data/<id>`, solidjs/solid#3094) with the
+ * bound query intact: submissions, `aria-busy`, redirects, revalidation,
+ * and single-flight all flow through the normal action machinery.
+ * Registered under the rendered url, so repeat submits reuse it (and a
+ * later real registration overrides it).
  */
 function createServerFormAction(
   url: string

--- a/src/data/action.ts
+++ b/src/data/action.ts
@@ -2,8 +2,10 @@ import { $TRACK, action as createSolidAction, createMemo, onCleanup, getOwner } 
 import { isResponseEnvelope, isServer, REVALIDATE_HEADER, type JSX } from "@solidjs/web";
 import {
   createServerReference,
+  decodeRedirectHeaderValue,
   decodeResponsePayload,
   parseServerFunctionUrl,
+  REDIRECT_HEADER,
   subscribeFlightData
 } from "@solidjs/web/server-functions";
 // The explicit /server specifier is safe here: the only call site is
@@ -414,6 +416,11 @@ async function settleActionResult<T>(result: T | Promise<T> | AsyncIterable<T>) 
 // again and wipe the freshly seeded cache).
 let flightApplications = 0;
 
+// The statuses fetch follows (Fetch §2.2.3) — the set the server masks into
+// the redirect carrier for scripted calls, and the set a locally-produced
+// redirect() envelope wears for real.
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
 /**
  * Registers the router as the single-flight consumer of the server function
  * transport. Subscribing is the opt-in: while registered, the transport
@@ -434,10 +441,11 @@ export function setupFlightDataConsumer(router: RouterContext) {
 
 /**
  * Applies a server function response's integration metadata: `X-Revalidate`
- * keys invalidate, `Location` navigates (hard for absolute urls), flight
- * data seeds the query cache, and matching entries revalidate. Shared by
- * the flight-data consumer and the action response path (which still sees
- * metadata-bearing responses when no flight data was collected).
+ * keys invalidate, the redirect carrier navigates (soft when same-origin,
+ * hard otherwise), flight data seeds the query cache, and matching entries
+ * revalidate. Shared by the flight-data consumer and the action response
+ * path (which still sees metadata-bearing responses when no flight data was
+ * collected).
  */
 function applyResponseMetadata(
   metadata: Response | undefined,
@@ -448,12 +456,32 @@ function applyResponseMetadata(
   if (metadata) {
     if (metadata.headers.has(REVALIDATE_HEADER))
       keys = metadata.headers.get(REVALIDATE_HEADER)!.split(",");
-    if (metadata.headers.has("Location")) {
-      const locationUrl = metadata.headers.get("Location") || "/";
-      if (locationUrl.startsWith("http")) {
-        window.location.href = locationUrl;
+    // The carrier delivers the target RESOLVED to an absolute url
+    // (solidjs/solid#3102), so the soft/hard split is a real origin
+    // comparison — never a guess from how the author spelled the target,
+    // which sent `redirect("/")` and `redirect(new URL("/", url).href)`
+    // down different navigation paths (solidjs/solid#3107). A redirect
+    // produced locally (a client-side action's `redirect()`) never crossed
+    // the wire, so no carrier was attached: it is the real 3xx with its
+    // Location, resolved against the page it runs in. A `Location` on any
+    // other status is the author's data (a 201's created-at) and never
+    // navigates. Same-origin targets navigate softly under the router;
+    // anything else leaves the app, so the document goes with it.
+    // `replace` matches what HTTP gives a form post: the target takes the
+    // submission's place in history rather than stacking on it.
+    const carried = decodeRedirectHeaderValue(metadata.headers.get(REDIRECT_HEADER));
+    const local =
+      !carried && REDIRECT_STATUSES.has(metadata.status) && metadata.headers.get("Location");
+    const target = carried
+      ? new URL(carried.url)
+      : local
+        ? new URL(local, window.location.href)
+        : undefined;
+    if (target) {
+      if (target.origin === window.location.origin) {
+        navigate(target.pathname + target.search + target.hash, { replace: true });
       } else {
-        navigate(locationUrl);
+        window.location.href = target.href;
       }
     }
   }

--- a/test/data/action.spec.ts
+++ b/test/data/action.spec.ts
@@ -222,15 +222,17 @@ describe("action", () => {
     const navigate = vi.fn();
     mockRouterContext.navigatorFactory = () => navigate;
 
+    // a real redirect: 302 + Location, what redirect() produces — a
+    // Location on a non-redirect status is data and never navigates
     const redirectAction = action(
-      async () => new Response(null, { headers: { Location: "/next" } }),
+      async () => new Response(null, { status: 302, headers: { Location: "/next" } }),
       { name: "redirect-settled-test" }
     ).onSettled(onSettled);
 
     const boundAction = useAction(redirectAction);
     await boundAction();
 
-    expect(navigate).toHaveBeenCalledWith("/next");
+    expect(navigate).toHaveBeenCalledWith("/next", { replace: true });
     expect(onSettled).toHaveBeenCalledTimes(1);
     expect(mockRouterContext.submissions[0]()).toHaveLength(0);
   });
@@ -799,7 +801,16 @@ describe("generic server actions", () => {
       return {};
     }) as any;
     originalFetch = global.fetch;
-    fetchMock = vi.fn(async () => new Response(null, { headers: { Location: "/after" } }));
+    // the wire shape of a scripted redirect: masked 200 with the carrier
+    // holding the author's status and the resolved target
+    fetchMock = vi.fn(
+      async () =>
+        new Response(null, {
+          headers: {
+            "X-Server-Function-Redirect": `302 ${new URL("/after", window.location.href).href}`
+          }
+        })
+    );
     global.fetch = fetchMock as any;
   });
 

--- a/test/data/action.spec.ts
+++ b/test/data/action.spec.ts
@@ -835,11 +835,12 @@ describe("generic server actions", () => {
     handleFormAction(event, mockRouterContext, ACTION_BASE);
 
     expect(event.preventDefault).toHaveBeenCalled();
-    // posted to the attribute url verbatim, as a server-function call —
-    // the id travels in the path, nowhere else (no addressing header)
+    // posted as a server-function call to the attribute url's data sibling
+    // (scripted calls have their own address, solidjs/solid#3094) — the id
+    // travels in the path, nowhere else (no addressing header)
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe(ref);
+    expect(url).toBe("/_server/data/echo%230");
     expect(init.method).toBe("POST");
     expect(init.headers["X-Server-Function-Id"]).toBeUndefined();
     expect(init.headers["X-Server-Function-Instance"]).toBeDefined();
@@ -857,7 +858,9 @@ describe("generic server actions", () => {
     handleFormAction(createSubmitEvent(form), mockRouterContext, ACTION_BASE);
 
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
-    expect(fetchMock.mock.calls[0][0]).toBe(ref);
+    // the data sibling keeps the rendered url's query — bound arguments ride
+    // where the server reads them for natural-encoding bodies
+    expect(fetchMock.mock.calls[0][0]).toBe("/_server/data/bound%230?args=%5B7%5D");
   });
 
   test("a registered action takes precedence over synthesis", () => {
@@ -891,7 +894,8 @@ describe("generic server actions", () => {
     submitServerForm(mockRouterContext, ref, form as any, {} as any);
 
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
-    expect(fetchMock.mock.calls[0][0]).toBe(ref);
+    expect(fetchMock.mock.calls[0][0]).toBe("/_server/data/lazy%230");
+    // registration stays under the RENDERED url — what repeat submits carry
     expect(actions.has(ref)).toBe(true);
   });
 

--- a/test/data/flight-consumer.spec.ts
+++ b/test/data/flight-consumer.spec.ts
@@ -7,9 +7,27 @@ import { createMockRouter } from "../helpers.js";
 // transport's part and deliver single-flight payloads to it directly.
 let consumer: FlightDataConsumer<Record<string, any>> | undefined;
 
+// The wire shape of a scripted redirect: masked 200 with the carrier holding
+// the author's status and the target resolved to an absolute url.
+const carrier = (target: string, status = 302) => ({
+  "X-Server-Function-Redirect": `${status} ${new URL(target, window.location.href).href}`
+});
+
 vi.mock("@solidjs/web/server-functions", () => ({
   decodeResponse: vi.fn(),
   decodeResponsePayload: vi.fn(),
+  // the redirect carrier, mirrored from the runtime (wire format:
+  // "<status> <absolute-url>")
+  REDIRECT_HEADER: "X-Server-Function-Redirect",
+  decodeRedirectHeaderValue: (value: string | null | undefined) => {
+    if (typeof value !== "string") return undefined;
+    const at = value.indexOf(" ");
+    if (at < 0) return undefined;
+    const status = Number(value.slice(0, at));
+    const url = value.slice(at + 1);
+    if (!Number.isInteger(status) || !url) return undefined;
+    return { status, url };
+  },
   // consumed by data/query.ts, which shares this module graph
   isServerFunction: () => false,
   getServerFunctionMetadata: () => undefined,
@@ -59,9 +77,9 @@ describe("setupFlightDataConsumer", () => {
     setupFlightDataConsumer(router);
     await consumer!(
       { "notes[]": ["destination data"] },
-      { response: new Response(null, { headers: { Location: "/notes" } }) }
+      { response: new Response(null, { headers: carrier("/notes") }) }
     );
-    expect(navigate).toHaveBeenCalledWith("/notes");
+    expect(navigate).toHaveBeenCalledWith("/notes", { replace: true });
     expect(query.get("notes[]")).toEqual(["destination data"]);
   });
 
@@ -110,13 +128,13 @@ describe("setupFlightDataConsumer", () => {
     const save = async () => {
       await consumer!(
         { "layout[]": "fresh-layout" },
-        { response: new Response(null, { headers: { Location: "/dash/b" } }) }
+        { response: new Response(null, { headers: carrier("/dash/b") }) }
       );
       return "saved";
     };
     await action(save, "keyless-save").call({ r: router });
 
-    expect(navigate).toHaveBeenCalledWith("/dash/b");
+    expect(navigate).toHaveBeenCalledWith("/dash/b", { replace: true });
     expect(await layout()).toBe("fresh-layout");
     expect(fetchLayout).toHaveBeenCalledTimes(1);
   });

--- a/test/data/flight-redirect.spec.ts
+++ b/test/data/flight-redirect.spec.ts
@@ -10,6 +10,18 @@ let consumer: FlightDataConsumer<Record<string, any>> | undefined;
 vi.mock("@solidjs/web/server-functions", () => ({
   decodeResponse: vi.fn(),
   decodeResponsePayload: vi.fn(),
+  // the redirect carrier, mirrored from the runtime (wire format:
+  // "<status> <absolute-url>")
+  REDIRECT_HEADER: "X-Server-Function-Redirect",
+  decodeRedirectHeaderValue: (value: string | null | undefined) => {
+    if (typeof value !== "string") return undefined;
+    const at = value.indexOf(" ");
+    if (at < 0) return undefined;
+    const status = Number(value.slice(0, at));
+    const url = value.slice(at + 1);
+    if (!Number.isInteger(status) || !url) return undefined;
+    return { status, url };
+  },
   // consumed by data/query.ts, which shares this module graph
   isServerFunction: () => false,
   getServerFunctionMetadata: () => undefined,
@@ -20,6 +32,12 @@ vi.mock("@solidjs/web/server-functions", () => ({
     };
   }
 }));
+
+// The wire shape of a scripted redirect: masked 200 with the carrier holding
+// the author's status and the target resolved to an absolute url.
+const carrier = (target: string, status = 302) => ({
+  "X-Server-Function-Redirect": `${status} ${new URL(target, window.location.href).href}`
+});
 
 // Spy on the sweep: these tests pin the ordering the action layer applies to
 // a flight response — invalidate, seed, navigate, then sweep synchronously —
@@ -70,7 +88,7 @@ describe("redirecting flight responses", () => {
     });
     await consumer!(
       { "note[0]": { title: "fresh" } },
-      { response: new Response(null, { headers: { Location: "/notes/0" } }) }
+      { response: new Response(null, { headers: carrier("/notes/0") }) }
     );
     expect(sweptDuringApply).toBe(true);
     expect(sweepSpy).toHaveBeenCalledTimes(1);
@@ -82,7 +100,7 @@ describe("redirecting flight responses", () => {
       { "notes[]": ["fresh"] },
       {
         response: new Response(null, {
-          headers: { Location: "/notes", "X-Revalidate": "notes" }
+          headers: { ...carrier("/notes"), "X-Revalidate": "notes" }
         })
       }
     );
@@ -109,7 +127,7 @@ describe("redirecting flight responses", () => {
       await consumer!(
         {},
         {
-          response: new Response(null, { headers: { Location: "https://elsewhere.example/" } })
+          response: new Response(null, { headers: carrier("https://elsewhere.example/") })
         }
       );
       expect(navigate).not.toHaveBeenCalled();

--- a/test/data/query.spec.ts
+++ b/test/data/query.spec.ts
@@ -164,7 +164,8 @@ describe("query", () => {
         expect(result).toBe("GET result");
         expect(bodyCalled).toBe(false);
         expect(seen.method).toBe("GET");
-        expect(seen.url).toContain("/_server/auto-get-0");
+        // scripted reads go to the data address (solidjs/solid#3094)
+        expect(seen.url).toContain("/_server/data/auto-get-0");
         // the declaration lives on the wrapped reference; the original's
         // metadata is untouched (copy-on-declare)
         expect(getServerFunctionMetadata(serverFn)).toEqual({});


### PR DESCRIPTION
## Summary

- solidjs/solid#3094 (landed on solid `next` as solidjs/solid@95229453) gives scripted server-function calls their own **data address**, `<endpoint>/data/<id>`, leaving the bare `<endpoint>/<id>` to plain HTTP — rendered action urls, no-JS form posts, direct callers. One answer shape per url means a shared cache can never replay one caller kind's answer to the other.
- **No functional router change was needed.** [#590](https://github.com/solidjs/solid-router/pull/590) already routed synthesized form actions through `parseServerFunctionUrl` + `createServerReference(id, undefined, url)` with the rendered url as base, and the new client transport re-addresses its own calls to the data sibling (bound `?args` intact). Registration, submissions, `actionBase` interception, flight data, and `.url`/`.with()` all stay on the rendered bare address by design.
- What changes here: wire-shape expectations in `action.spec.ts` / `query.spec.ts` (the transport's fetch url is now the data sibling) and the `createServerFormAction` doc comment.

Draft until the @solidjs/web release carrying the split (next after 2.0.0-rc.4); CI against rc.4 will show the three updated expectations failing until then.

## Test plan

- [x] Both vitest configs pass against the workspace @solidjs/web build carrying the split (30 files / 382 tests + 6 files / 33 tests)
- [ ] Re-run CI once the next @solidjs/web ships and the dep resolves to it

Made with [Cursor](https://cursor.com)